### PR TITLE
feat: add torch-fl backend for Enflame

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -209,6 +209,10 @@ This document provides a comprehensive reference for all environment variables u
 | `FLAGCX_DEVICE_ADAPTOR_PLUGIN` | None | Path to device adaptor plugin shared library |
 | `FLAGCX_NET_ADAPTOR_PLUGIN` | None | Path to network adaptor plugin shared library |
 | `FLAGCX_CCL_ADAPTOR_PLUGIN` | None | Path to CCL adaptor plugin shared library |
+| `FLAGCX_TORCH_BACKEND` | `torch_gcu` | Torch integration used by the Enflame plugin. Set to `flagos` to build and load against torch-fl without importing or linking `torch_gcu` |
+| `FLAGOS_INSTALL_PATH` | None | torch-fl package root containing `include/flagos.h` and `lib/libflagos.so` for `FLAGCX_TORCH_BACKEND=flagos` builds |
+| `FLAGOS_INCLUDE_DIR` | None | Explicit directory containing `flagos.h`; overrides the include path derived from `FLAGOS_INSTALL_PATH` |
+| `FLAGOS_LIBRARY_DIR` | None | Explicit directory containing `libflagos.so`; overrides the library path derived from `FLAGOS_INSTALL_PATH` |
 
 ---
 

--- a/makefiles/enflame.mk
+++ b/makefiles/enflame.mk
@@ -19,4 +19,4 @@ ADAPTOR_FLAG := -DUSE_ENFLAME_ADAPTOR
 
 PLATFORM_KERNEL_DIR  :=
 PLATFORM_KERNEL_SRCS :=
-PLATFORM_EXTRA_SRCS  :=
+PLATFORM_EXTRA_SRCS  := flagcx/adaptor/device_api/default_dev_api_backend.cc

--- a/plugin/torch/_build_config.py
+++ b/plugin/torch/_build_config.py
@@ -209,12 +209,55 @@ def get_device_config(adaptor_flag):
         library_dirs += ["/usr/local/kuiper/lib", txda_library_path]
         libs += ["torch_txda", "hpgr"]
     elif adaptor_flag == "-DUSE_ENFLAME_ADAPTOR":
-        import torch_gcu
-        pytorch_gcu_install_path = os.path.dirname(os.path.abspath(torch_gcu.__file__))
-        pytorch_library_path = os.path.join(pytorch_gcu_install_path, "lib")
-        include_dirs += ["/opt/tops/include", os.path.join(pytorch_gcu_install_path, "include")]
-        library_dirs += ["/opt/tops/lib", pytorch_library_path]
-        libs += ["topsrt", "torch_gcu"]
+        include_dirs += ["/opt/tops/include"]
+        library_dirs += ["/opt/tops/lib"]
+        libs += ["topsrt"]
+        if os.environ.get("FLAGCX_TORCH_BACKEND", "torch_gcu").strip().lower() == "flagos":
+            # torch_fl owns the PrivateUse1 stream/event implementation. Keep
+            # this mode independent of the vendor torch_gcu package.
+            flagos_install_path = os.environ.get("FLAGOS_INSTALL_PATH", "")
+            flagos_include_dir = os.environ.get("FLAGOS_INCLUDE_DIR", "")
+            flagos_library_dir = os.environ.get("FLAGOS_LIBRARY_DIR", "")
+            if flagos_install_path:
+                flagos_include_dir = flagos_include_dir or os.path.join(
+                    flagos_install_path, "include"
+                )
+                flagos_library_dir = flagos_library_dir or os.path.join(
+                    flagos_install_path, "lib"
+                )
+            if not flagos_include_dir or not flagos_library_dir:
+                import torch_fl
+
+                torch_fl_path = os.path.dirname(os.path.abspath(torch_fl.__file__))
+                flagos_include_dir = flagos_include_dir or os.path.join(
+                    torch_fl_path, "include"
+                )
+                flagos_library_dir = flagos_library_dir or os.path.join(
+                    torch_fl_path, "lib"
+                )
+                if not os.path.isfile(os.path.join(flagos_include_dir, "flagos.h")):
+                    source_root = os.path.dirname(torch_fl_path)
+                    flagos_include_dir = os.path.join(source_root, "csrc", "include")
+            if not os.path.isfile(os.path.join(flagos_include_dir, "flagos.h")):
+                raise RuntimeError(
+                    "FLAGCX_TORCH_BACKEND=flagos requires flagos.h; set "
+                    "FLAGOS_INSTALL_PATH or FLAGOS_INCLUDE_DIR"
+                )
+            if not os.path.isfile(os.path.join(flagos_library_dir, "libflagos.so")):
+                raise RuntimeError(
+                    "FLAGCX_TORCH_BACKEND=flagos requires libflagos.so; set "
+                    "FLAGOS_INSTALL_PATH or FLAGOS_LIBRARY_DIR"
+                )
+            include_dirs += [flagos_include_dir]
+            library_dirs += [flagos_library_dir]
+            libs += ["flagos"]
+        else:
+            import torch_gcu
+            pytorch_gcu_install_path = os.path.dirname(os.path.abspath(torch_gcu.__file__))
+            pytorch_library_path = os.path.join(pytorch_gcu_install_path, "lib")
+            include_dirs += [os.path.join(pytorch_gcu_install_path, "include")]
+            library_dirs += [pytorch_library_path]
+            libs += ["torch_gcu"]
     elif adaptor_flag == "-DUSE_SUNRISE_ADAPTOR":
         import torch_ptpu
         torch_ptpu_dir = os.path.dirname(os.path.abspath(torch_ptpu.__file__))
@@ -237,6 +280,29 @@ def get_device_config(adaptor_flag):
         libs += ["cuda", "cudart", "c10_cuda", "torch_cuda"]
 
     return include_dirs, library_dirs, libs
+
+
+def get_device_rpath_dirs(adaptor_flag, library_dirs):
+    """Return runtime library paths that belong in the extension artifact."""
+    if (
+        adaptor_flag == "-DUSE_ENFLAME_ADAPTOR"
+        and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos"
+    ):
+        flagos_library_dir = os.environ.get("FLAGOS_LIBRARY_DIR", "")
+        flagos_install_path = os.environ.get("FLAGOS_INSTALL_PATH", "")
+        if not flagos_library_dir and flagos_install_path:
+            flagos_library_dir = os.path.join(flagos_install_path, "lib")
+        if not flagos_library_dir:
+            try:
+                import torch_fl
+
+                flagos_library_dir = os.path.join(
+                    os.path.dirname(os.path.abspath(torch_fl.__file__)), "lib"
+                )
+            except ImportError:
+                pass
+        return [path for path in library_dirs if path != flagos_library_dir]
+    return list(library_dirs)
 
 
 def get_ext_classes(adaptor_flag):

--- a/plugin/torch/flagcx/__init__.py
+++ b/plugin/torch/flagcx/__init__.py
@@ -13,6 +13,10 @@ os.environ.pop('TORCH_DEVICE_BACKEND_AUTOLOAD')
 # will later try to register the same accelerator again, causing a
 # "Two accelerators cannot be used at the same time" error.
 _DEVICE_BACKENDS = ["torch_npu", "torch_mlu", "torch_musa", "torch_txda", "torch_gcu", "torch_ptpu"]
+if os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
+    import torch_fl  # noqa: F401 - loads libflagos.so before the extension
+
+    _DEVICE_BACKENDS.remove("torch_gcu")
 for _pkg in _DEVICE_BACKENDS:
     try:
         __import__(_pkg)
@@ -35,7 +39,9 @@ def init():
     pass
 
 def replace_prefix(arg):
-    device_list = ["cuda", "mlu", "npu", "musa", "txda", "gcu", "ptpu"]
+    device_list = [
+        "cuda", "mlu", "npu", "musa", "txda", "gcu", "flagos", "ptpu"
+    ]
     flagcx_prefix = "flagcx_dev"
     if isinstance(arg, str):
         for string in device_list:

--- a/plugin/torch/flagcx/include/backend_flagcx.hpp
+++ b/plugin/torch/flagcx/include/backend_flagcx.hpp
@@ -78,6 +78,7 @@ private:
   flagcxStream_t stream_;
   flagcxDeviceHandle_t devHandle_;
   c10::intrusive_ptr<c10::ivalue::Future> future_;
+  std::vector<at::Tensor> stashedTensors_;
   int deviceId_;
   bool isBarrierOp_;
   std::unique_ptr<flagcxEvent> event_;
@@ -247,7 +248,11 @@ public:
 #elif USE_TSM_ADAPTOR
     devName = "txda";
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+    devName = "flagos";
+#else
     devName = "gcu";
+#endif
 #elif USE_SUNRISE_ADAPTOR
     devName = "ptpu";
 #endif

--- a/plugin/torch/flagcx/include/event_flagcx.hpp
+++ b/plugin/torch/flagcx/include/event_flagcx.hpp
@@ -337,9 +337,9 @@ class flagcxTopsEvent : public flagcxEvent {
 public:
 #ifdef FLAGCX_TORCH_BACKEND_FLAGOS
   flagcxTopsEvent() {
-    TORCH_CHECK(
-        topsEventCreateWithFlags(&event_, topsEventDisableTiming) == topsSuccess,
-        "topsEventCreateWithFlags failed");
+    TORCH_CHECK(topsEventCreateWithFlags(&event_, topsEventDisableTiming) ==
+                    topsSuccess,
+                "topsEventCreateWithFlags failed");
   }
 
   ~flagcxTopsEvent() override {
@@ -349,32 +349,29 @@ public:
   }
 
   void record(const int deviceId) override {
-    TORCH_CHECK(
-        topsEventRecord(event_, reinterpret_cast<topsStream_t>(
-            GetCurrentStreamForDevice(deviceId))) == topsSuccess,
-        "topsEventRecord failed");
+    TORCH_CHECK(topsEventRecord(event_, reinterpret_cast<topsStream_t>(
+                                            GetCurrentStreamForDevice(
+                                                deviceId))) == topsSuccess,
+                "topsEventRecord failed");
   }
 
   void record(const flagcxStream_t &stream, const int /*deviceId*/) override {
-    TORCH_CHECK(
-        topsEventRecord(event_, *reinterpret_cast<topsStream_t *>(stream)) ==
-            topsSuccess,
-        "topsEventRecord failed");
+    TORCH_CHECK(topsEventRecord(event_, *reinterpret_cast<topsStream_t *>(
+                                            stream)) == topsSuccess,
+                "topsEventRecord failed");
   }
 
   void block(const int deviceId) override {
-    TORCH_CHECK(
-        topsStreamWaitEvent(
-            reinterpret_cast<topsStream_t>(GetCurrentStreamForDevice(deviceId)),
-            event_, 0) == topsSuccess,
-        "topsStreamWaitEvent failed");
+    TORCH_CHECK(topsStreamWaitEvent(reinterpret_cast<topsStream_t>(
+                                        GetCurrentStreamForDevice(deviceId)),
+                                    event_, 0) == topsSuccess,
+                "topsStreamWaitEvent failed");
   }
 
   void block(const flagcxStream_t &stream, const int /*deviceId*/) override {
-    TORCH_CHECK(
-        topsStreamWaitEvent(*reinterpret_cast<topsStream_t *>(stream), event_, 0) ==
-            topsSuccess,
-        "topsStreamWaitEvent failed");
+    TORCH_CHECK(topsStreamWaitEvent(*reinterpret_cast<topsStream_t *>(stream),
+                                    event_, 0) == topsSuccess,
+                "topsStreamWaitEvent failed");
   }
 
 private:

--- a/plugin/torch/flagcx/include/event_flagcx.hpp
+++ b/plugin/torch/flagcx/include/event_flagcx.hpp
@@ -39,9 +39,14 @@
 #include "torch_txda/csrc/core/TXDAStream.h"
 #include <tx_runtime.h>
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+#include <flagos.h>
+#include <tops/tops_runtime_api.h>
+#else
 #include <gcu/gcu_event.h>
 #include <gcu/gcu_guard.h>
 #include <tops/tops_runtime_api.h>
+#endif
 #elif USE_SUNRISE_ADAPTOR
 #include <tang_runtime.h>
 #include <torch_ptpu/core/Event.h>
@@ -330,6 +335,51 @@ private:
 #elif USE_ENFLAME_ADAPTOR
 class flagcxTopsEvent : public flagcxEvent {
 public:
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  flagcxTopsEvent() {
+    TORCH_CHECK(
+        topsEventCreateWithFlags(&event_, topsEventDisableTiming) == topsSuccess,
+        "topsEventCreateWithFlags failed");
+  }
+
+  ~flagcxTopsEvent() override {
+    if (event_ != nullptr) {
+      topsEventDestroy(event_);
+    }
+  }
+
+  void record(const int deviceId) override {
+    TORCH_CHECK(
+        topsEventRecord(event_, reinterpret_cast<topsStream_t>(
+            GetCurrentStreamForDevice(deviceId))) == topsSuccess,
+        "topsEventRecord failed");
+  }
+
+  void record(const flagcxStream_t &stream, const int /*deviceId*/) override {
+    TORCH_CHECK(
+        topsEventRecord(event_, *reinterpret_cast<topsStream_t *>(stream)) ==
+            topsSuccess,
+        "topsEventRecord failed");
+  }
+
+  void block(const int deviceId) override {
+    TORCH_CHECK(
+        topsStreamWaitEvent(
+            reinterpret_cast<topsStream_t>(GetCurrentStreamForDevice(deviceId)),
+            event_, 0) == topsSuccess,
+        "topsStreamWaitEvent failed");
+  }
+
+  void block(const flagcxStream_t &stream, const int /*deviceId*/) override {
+    TORCH_CHECK(
+        topsStreamWaitEvent(*reinterpret_cast<topsStream_t *>(stream), event_, 0) ==
+            topsSuccess,
+        "topsStreamWaitEvent failed");
+  }
+
+private:
+  topsEvent_t event_ = nullptr;
+#else
   flagcxTopsEvent() { topsEvent_ = torch_gcu::GCUEvent(); }
 
   void record(const int deviceId) override {
@@ -352,6 +402,7 @@ public:
 
 private:
   torch_gcu::GCUEvent topsEvent_;
+#endif
 };
 #elif USE_SUNRISE_ADAPTOR
 class flagcxPtpuEvent : public flagcxEvent {

--- a/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
+++ b/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
@@ -53,10 +53,15 @@
 #include <c10/core/impl/InlineStreamGuard.h>
 #include <tx_runtime.h>
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+#include <flagos.h>
+#include <tops/tops_runtime_api.h>
+#else
 #include <c10/core/impl/InlineStreamGuard.h>
 #include <gcu/gcu_guard.h>
 #include <gcu/gcu_stream.h>
 #include <tops/tops_runtime_api.h>
+#endif
 #elif USE_SUNRISE_ADAPTOR
 #include <torch_ptpu/core/Stream.h>
 #endif
@@ -98,8 +103,15 @@ public:
         guard_(
             torch_txda::getStreamFromExternal(*(txStream_t *)stream, deviceId))
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+        guard_(*reinterpret_cast<topsStream_t *>(stream)),
+        previous_(reinterpret_cast<topsStream_t>(
+            GetCurrentStreamForDevice(deviceId))),
+        previousDevice_(0)
+#else
         guard_(
             torch_gcu::getStreamFromExternal(*(topsStream_t *)stream, deviceId))
+#endif
 // torch_ptpu intentionally does not expose a getStreamFromExternal-style API.
 // Instead we pick a stream from the pool, run torch ops on it, and rely on
 // flagcxBackend::syncStream() / flagcxPtpuEvent for cross-stream
@@ -109,11 +121,21 @@ public:
         guard_(torchpt::get_stream_from_pool(deviceId, /*prio=*/0))
 #endif
   {
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+    GetDevice(&previousDevice_);
+    SetDevice(deviceId_);
+    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(guard_));
+#endif
 #ifdef USE_SUNRISE_ADAPTOR
     torchpt::set_current_stream(guard_.unwrap());
 #endif
   }
-#ifdef USE_SUNRISE_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  ~flagcxStreamGuard() {
+    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(previous_));
+    SetDevice(previousDevice_);
+  }
+#elif USE_SUNRISE_ADAPTOR
   // torchpt::PTPUStream is a value type, not an RAII guard, so we have
   // to restore the previous current stream by hand on destruction.
   ~flagcxStreamGuard() {
@@ -162,8 +184,13 @@ public:
     guard_.reset_stream(
         torch_txda::getStreamFromExternal(*(txStream_t *)stream, deviceId_));
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+    guard_ = *reinterpret_cast<topsStream_t *>(stream);
+    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(guard_));
+#else
     guard_.reset_stream(
         torch_gcu::getStreamFromExternal(*(topsStream_t *)stream, deviceId_));
+#endif
 #elif USE_SUNRISE_ADAPTOR
     guard_ = torchpt::get_stream_from_pool(deviceId_, /*prio=*/0);
     torchpt::set_current_stream(guard_.unwrap());
@@ -200,7 +227,13 @@ private:
 #elif USE_TSM_ADAPTOR
   torch_txda::TXDAStreamGuard guard_;
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  topsStream_t guard_;
+  topsStream_t previous_;
+  int previousDevice_;
+#else
   torch_gcu::GCUStreamGuard guard_;
+#endif
 #elif USE_SUNRISE_ADAPTOR
   torchpt::PTPUStream sunrisePrevStream_;
   torchpt::PTPUStream guard_;

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -722,10 +722,11 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
       flagcxStreamGuard guard(stream, device.index());
       for (const auto j : c10::irange(outputTensorsTmp.size())) {
         C10D_FLAGCX_CHECK(
-            devHandle_->deviceMemcpy(
-                outputTensorsTmp[j].data_ptr(), outputFlattened[j].data_ptr(),
-                outputTensorsTmp[j].numel() * outputTensorsTmp[j].element_size(),
-                flagcxMemcpyDeviceToDevice, stream),
+            devHandle_->deviceMemcpy(outputTensorsTmp[j].data_ptr(),
+                                     outputFlattened[j].data_ptr(),
+                                     outputTensorsTmp[j].numel() *
+                                         outputTensorsTmp[j].element_size(),
+                                     flagcxMemcpyDeviceToDevice, stream),
             std::nullopt);
       }
     }

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -266,14 +266,32 @@ bool flagcxWork::isCompleted() { return future_->completed(); }
 bool flagcxWork::isSuccess() const { return future_->hasValue(); }
 
 bool flagcxWork::wait(std::chrono::milliseconds /* unused */) {
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  int previousDevice = 0;
+  C10D_FLAGCX_CHECK(devHandle_->getDevice(&previousDevice), std::nullopt);
+  C10D_FLAGCX_CHECK(devHandle_->setDevice(deviceId_), std::nullopt);
+  try {
+    event_->block(deviceId_);
+    C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream_), std::nullopt);
+  } catch (...) {
+    devHandle_->setDevice(previousDevice);
+    throw;
+  }
+  C10D_FLAGCX_CHECK(devHandle_->setDevice(previousDevice), std::nullopt);
+#else
   event_->block(deviceId_);
   if (isBarrierOp_) {
     C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream_), std::nullopt);
   }
+#endif
+  stashedTensors_.clear();
   return true;
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> flagcxWork::getFuture() {
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  wait();
+#endif
   return future_;
 }
 
@@ -666,6 +684,7 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
   initComm(device);
   syncStream(device);
 
+  at::Tensor outputFlattened;
   if (!check_same_size(outputTensorsTmp)) {
     // Implement allgather with different sizes using broadcast
     const auto num_reduces = outputTensorsTmp.size();
@@ -680,7 +699,7 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
     }
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
-    at::Tensor outputFlattened = newLikeFlat(outputTensorsTmp);
+    outputFlattened = newLikeFlat(outputTensorsTmp);
 
 #if (defined(USE_NVIDIA_ADAPTOR) || defined(USE_METAX_ADAPTOR)) &&             \
     defined(TORCH_VER_GE_250)
@@ -696,11 +715,18 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
                         inputTensor.numel(), flagcxDataType, comm_, stream),
         std::nullopt);
 
-    // Copy the flattened tensor back into a vector of tensors.
+    // Copy the contiguous receive buffer back without dispatching an ATen
+    // copy kernel. GCU's int64 copy path is not reliable, and DDP uses int64
+    // tensors for parameter-shape verification.
     {
       flagcxStreamGuard guard(stream, device.index());
       for (const auto j : c10::irange(outputTensorsTmp.size())) {
-        outputTensorsTmp[j].copy_(outputFlattened[j], true);
+        C10D_FLAGCX_CHECK(
+            devHandle_->deviceMemcpy(
+                outputTensorsTmp[j].data_ptr(), outputFlattened[j].data_ptr(),
+                outputTensorsTmp[j].numel() * outputTensorsTmp[j].element_size(),
+                flagcxMemcpyDeviceToDevice, stream),
+            std::nullopt);
       }
     }
   }
@@ -709,6 +735,12 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
       c10::make_intrusive<flagcxWork>(OpType::ALLGATHER, stream, devHandle_);
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  if (outputFlattened.defined()) {
+    work->stashedTensors_.push_back(std::move(outputFlattened));
+  }
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream), std::nullopt);
+#endif
   // Create a future to track the allgather operation
   std::vector<at::Device> devices{inputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -915,6 +947,8 @@ flagcxBackend::alltoall(std::vector<at::Tensor> &outputTensors,
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  work->stashedTensors_.push_back(std::move(inputFlattened));
+  work->stashedTensors_.push_back(std::move(outputFlattened));
   // Create a future to track the alltoall operation
   std::vector<at::Device> devices{device};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1093,6 +1127,7 @@ flagcxBackend::gather(std::vector<std::vector<at::Tensor>> &outputTensors,
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  work->stashedTensors_.push_back(std::move(outputFlattened));
   // Create a future to track the gather operation
   std::vector<at::Device> devices{inputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1155,12 +1190,13 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce_scatter(
   initComm(device);
   syncStream(device);
 
+  at::Tensor inputFlattened;
   if (!check_same_size(inputTensorsTmp)) {
     throw std::runtime_error(
         "flagcx only support same size reducescatter operation");
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
-    at::Tensor inputFlattened = newLikeFlat(inputTensorsTmp);
+    inputFlattened = newLikeFlat(inputTensorsTmp);
 
     // Copy the input tensors to the flattened tensor.
     {
@@ -1189,6 +1225,7 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce_scatter(
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  work->stashedTensors_.push_back(std::move(inputFlattened));
   // Create a future to track the reducescatter operation
   std::vector<at::Device> devices{outputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1322,6 +1359,7 @@ flagcxBackend::scatter(std::vector<at::Tensor> &outputTensors,
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  work->stashedTensors_.push_back(std::move(inputFlattened));
   // Create a future to track the scatter operation
   std::vector<at::Device> devices{outputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(

--- a/plugin/torch/setup.py
+++ b/plugin/torch/setup.py
@@ -16,6 +16,7 @@ from _build_config import (
     detect_adaptor,
     detect_torch_flag,
     get_device_config,
+    get_device_rpath_dirs,
     get_ext_classes,
 )
 
@@ -24,6 +25,10 @@ print(f"Using {adaptor} adaptor")
 
 adaptor_flag = ADAPTOR_MAP[adaptor]
 torch_flag = detect_torch_flag()
+torch_backend_flags = []
+if adaptor == "enflame" and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
+    # Compile the Enflame plugin against torch_fl's C ABI instead of torch_gcu.
+    torch_backend_flags.append("-DFLAGCX_TORCH_BACKEND_FLAGOS")
 
 plugin_dir = os.path.dirname(os.path.abspath(__file__))
 repo_root = os.path.join(plugin_dir, "..", "..")
@@ -56,10 +61,13 @@ if CppExtension is not None:
         sources=sources,
         include_dirs=include_dirs,
         extra_compile_args={
-            'cxx': [adaptor_flag, torch_flag]
+            'cxx': [adaptor_flag, torch_flag] + torch_backend_flags
         },
         extra_link_args=["-Wl,-rpath," + os.path.join(repo_root, "build", "lib")]
-                        + ["-Wl,-rpath," + d for d in dev_libdirs],
+                        + [
+                            "-Wl,-rpath," + d
+                            for d in get_device_rpath_dirs(adaptor_flag, dev_libdirs)
+                        ],
         library_dirs=library_dirs,
         libraries=libs,
     )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ from _build_config import (
     detect_adaptor,
     detect_torch_flag,
     get_device_config,
+    get_device_rpath_dirs,
     get_ext_classes,
 )
 
@@ -38,6 +39,10 @@ print(f"[flagcx] Using {adaptor} adaptor")
 adaptor_flag = ADAPTOR_MAP[adaptor]
 adaptor_make_flag = ADAPTOR_TO_MAKE_FLAG[adaptor]
 torch_flag = detect_torch_flag()
+torch_backend_flags = []
+if adaptor == "enflame" and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
+    # Compile the Enflame plugin against torch_fl's C ABI instead of torch_gcu.
+    torch_backend_flags.append("-DFLAGCX_TORCH_BACKEND_FLAGOS")
 
 # ---------------------------------------------------------------------------
 # Extension sources and include dirs
@@ -133,7 +138,10 @@ if BuildExtension is not None:
                 # Set $ORIGIN rpath so _C.so finds libflagcx.so in the same directory
                 # Preserve device-specific rpaths so runtime linker can find device libs
                 origin_rpath = "-Wl,-rpath,$ORIGIN"
-                dev_rpaths = ["-Wl,-rpath," + d for d in dev_libdirs]
+                dev_rpaths = [
+                    "-Wl,-rpath," + d
+                    for d in get_device_rpath_dirs(adaptor_flag, dev_libdirs)
+                ]
                 ext.extra_link_args = [
                     arg for arg in ext.extra_link_args
                     if not arg.startswith("-Wl,-rpath,")
@@ -171,7 +179,9 @@ if CppExtension is not None:
         name="flagcx._C",
         sources=sources,
         include_dirs=include_dirs,
-        extra_compile_args={"cxx": [adaptor_flag, torch_flag]},
+        extra_compile_args={
+            "cxx": [adaptor_flag, torch_flag] + torch_backend_flags
+        },
         extra_link_args=[],
         library_dirs=library_dirs,
         libraries=libs,


### PR DESCRIPTION
### PR Category
PAL (Portable Abstraction Layer)

### PR Types
New Features

### PR Description

This PR adds an opt-in torch-fl-compatible Enflame GCU backend for the FlagCX PyTorch plugin, following the design discussed in issue #544.

When `FLAGCX_TORCH_BACKEND=flagos` is set, the plugin:

- Imports `torch_fl` and registers the `flagos` device backend.
- Links against the installed `libflagos.so` and `libtopsrt.so` runtime libraries.
- Uses the exported torch-fl stream and event ABI so FlagCX and torch-fl share device-scoped stream state across DSOs.
- Does not import or link `torch_gcu`.
- Keeps the existing vendor mode unchanged when the variable is unset; the default path continues to use `torch_gcu` and the `gcu` device name.

The implementation also:

- Adds Enflame stream guards and native Tops event handling.
- Preserves asynchronous temporary tensors until the corresponding FlagCX work completes.
- Synchronizes FlagOS work before host-visible `wait()` and `getFuture()` results are consumed.
- Resolves the communicator device before tensor-less barriers and restores the caller's previous device and stream.
- Uses raw FlagCX device-to-device copies for the GCU int64 list all-gather path, avoiding the unreliable GCU ATen int64 copy path.
- Adds build and packaging support for locating `flagos.h`, `libflagos.so`, and the Tops runtime through `FLAGOS_INSTALL_PATH`, `FLAGOS_INCLUDE_DIR`, and `FLAGOS_LIBRARY_DIR`.

Validation on a two-card Enflame S60 system with the torch-fl-compatible mode enabled:

- All-reduce, broadcast, all-gather, all-gather-into-tensor, reduce-scatter, and barrier passed.
- DDP forward and backward passed.
- FSDP2 per-layer training, mixed precision, gradient clipping, and sharded state-dict save/load passed.
- Clean wheel packaging was checked, including the absence of `torch_gcu` from the FlagOS-mode import and ELF dependency path.
- The FlagCX source change passes `git diff --check`.

The following scenarios remain to be validated on Enflame hardware: point-to-point operations, gather/scatter roots, all-to-all, multi-node rendezvous, process-failure recovery, and more than two devices. `getFuture()` currently uses a host-synchronous completion path in FlagOS mode; an event-backed future can be added separately.
