### PR TITLE
[CRL] Use private vendor unique IDs for homogeneous communicators

### DIFF
--- a/flagcx/adaptor/ccl/bootstrap_adaptor.cc
+++ b/flagcx/adaptor/ccl/bootstrap_adaptor.cc
@@ -13,7 +13,7 @@ flagcxResult_t bootstrapAdaptorGetVersion(int *version) {
 }
 
 // TODO: unsupported
-flagcxResult_t bootstrapAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t bootstrapAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   return flagcxNotSupported;
 }
 
@@ -71,7 +71,7 @@ const char *bootstrapAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t bootstrapAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                            flagcxUniqueId_t /*commId*/,
+                                            flagcxInnerUniqueId_t /*commId*/,
                                             int rank,
                                             struct bootstrapState *bootstrap) {
   if (*comm == NULL) {

--- a/flagcx/adaptor/ccl/cncl_adaptor.cc
+++ b/flagcx/adaptor/ccl/cncl_adaptor.cc
@@ -7,6 +7,9 @@
 #include "comm.h"
 #include <map>
 
+static_assert(sizeof(cnclCliqueId) <= sizeof(flagcxInnerUniqueId),
+              "cnclCliqueId does not fit inside flagcxInnerUniqueId");
+
 std::map<flagcxDataType_t, cnclDataType_t> f2c_datatype_map = {
     {flagcxInt8, cnclInt8},       {flagcxUint8, cnclUint8},
     {flagcxInt, cnclInt},         {flagcxInt32, cnclInt32},
@@ -38,7 +41,7 @@ flagcxResult_t cnclAdaptorGetVersion(int *version) {
   return flagcxUnhandledDeviceError;
 }
 
-flagcxResult_t cnclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t cnclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -63,7 +66,7 @@ const char *cnclAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t cnclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/dunccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/dunccl_adaptor.cc
@@ -6,11 +6,14 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(ncclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "ncclUniqueId does not fit inside flagcxInnerUniqueId");
+
 flagcxResult_t duncclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)ncclGetVersion(version);
 }
 
-flagcxResult_t duncclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t duncclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -33,7 +36,7 @@ const char *duncclAdaptorGetLastError(flagcxInnerComm_t comm) {
 
 flagcxResult_t
 duncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                          flagcxUniqueId_t commId, int rank,
+                          flagcxInnerUniqueId_t commId, int rank,
                           struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/eccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/eccl_adaptor.cc
@@ -10,11 +10,14 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(ecclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "ecclUniqueId does not fit inside flagcxInnerUniqueId");
+
 flagcxResult_t ecclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)ecclGetVersion(version);
 }
 
-flagcxResult_t ecclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t ecclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -36,7 +39,7 @@ flagcxResult_t ecclAdaptorGetStagedBuffer(const flagcxInnerComm_t comm,
 }
 
 flagcxResult_t ecclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/gloo_adaptor.cc
+++ b/flagcx/adaptor/ccl/gloo_adaptor.cc
@@ -21,7 +21,7 @@ flagcxResult_t glooAdaptorGetVersion(int *version) {
 }
 
 // TODO: unsupported
-flagcxResult_t glooAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t glooAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   return flagcxNotSupported;
 }
 
@@ -84,7 +84,8 @@ const char *glooAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t glooAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t /*commId*/, int rank,
+                                       flagcxInnerUniqueId_t /*commId*/,
+                                       int rank,
                                        struct bootstrapState *bootstrap) {
   // Create gloo transport device
   std::shared_ptr<::gloo::transport::Device> dev;

--- a/flagcx/adaptor/ccl/hccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/hccl_adaptor.cc
@@ -7,6 +7,10 @@
 #include "comm.h"
 #include <map>
 #include <vector>
+
+static_assert(sizeof(HcclRootInfo) <= sizeof(flagcxInnerUniqueId),
+              "HcclRootInfo does not fit inside flagcxInnerUniqueId");
+
 std::map<flagcxDataType_t, HcclDataType> f2h_datatype_map = {
     {flagcxInt8, HCCL_DATA_TYPE_INT8},
     {flagcxUint8, HCCL_DATA_TYPE_UINT8},
@@ -75,7 +79,7 @@ flagcxResult_t hcclAdaptorGetVersion(int *version) {
   return flagcxNotSupported;
 }
 
-flagcxResult_t hcclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t hcclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   return (
       flagcxResult_t)h2f_ret_map[HcclGetRootInfo((HcclRootInfo *)(*uniqueId))];
 }
@@ -96,7 +100,7 @@ const char *hcclAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t hcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/ixnccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/ixnccl_adaptor.cc
@@ -6,11 +6,14 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(ncclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "ncclUniqueId does not fit inside flagcxInnerUniqueId");
+
 flagcxResult_t ixncclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)ncclGetVersion(version);
 }
 
-flagcxResult_t ixncclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t ixncclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -33,7 +36,7 @@ const char *ixncclAdaptorGetLastError(flagcxInnerComm_t comm) {
 
 flagcxResult_t
 ixncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                          flagcxUniqueId_t commId, int rank,
+                          flagcxInnerUniqueId_t commId, int rank,
                           struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/mccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/mccl_adaptor.cc
@@ -11,11 +11,14 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(mcclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "mcclUniqueId does not fit inside flagcxInnerUniqueId");
+
 flagcxResult_t mcclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)mcclGetVersion(version);
 }
 
-flagcxResult_t mcclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t mcclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -37,7 +40,7 @@ const char *mcclAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/mpi_adaptor.cc
+++ b/flagcx/adaptor/ccl/mpi_adaptor.cc
@@ -27,7 +27,7 @@ flagcxResult_t mpiAdaptorGetVersion(int *version) {
   return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
 }
 
-flagcxResult_t mpiAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t mpiAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   return flagcxSuccess;
 }
 
@@ -90,7 +90,8 @@ const char *mpiAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t mpiAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                      flagcxUniqueId_t /*commId*/, int rank,
+                                      flagcxInnerUniqueId_t /*commId*/,
+                                      int rank,
                                       struct bootstrapState *bootstrap) {
   int initialized;
   MPI_Initialized(&initialized);

--- a/flagcx/adaptor/ccl/musa_mccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/musa_mccl_adaptor.cc
@@ -6,11 +6,14 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(mcclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "mcclUniqueId does not fit inside flagcxInnerUniqueId");
+
 flagcxResult_t mcclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)mcclGetVersion(version);
 }
 
-flagcxResult_t mcclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t mcclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -33,7 +36,7 @@ const char *mcclAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/nccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/nccl_adaptor.cc
@@ -6,6 +6,9 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(ncclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "ncclUniqueId does not fit inside flagcxInnerUniqueId");
+
 static bool checkIsAllCudaP2p(ncclComm_t comm) {
   int gpuCount;
   if (cudaGetDeviceCount(&gpuCount) != cudaSuccess) {
@@ -41,7 +44,7 @@ flagcxResult_t ncclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)ncclGetVersion(version);
 }
 
-flagcxResult_t ncclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t ncclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -105,7 +108,7 @@ const char *ncclAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t ncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     void *p = malloc(sizeof(struct flagcxInnerComm));

--- a/flagcx/adaptor/ccl/pccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/pccl_adaptor.cc
@@ -3,6 +3,9 @@
 #ifdef USE_SUNRISE_ADAPTOR
 #include <map>
 
+static_assert(sizeof(pcclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "pcclUniqueId does not fit inside flagcxInnerUniqueId");
+
 // Datatype and reduction op mappings
 std::map<flagcxDataType_t, pcclDataType_t> f2p_datatype_map = {
     {flagcxInt8, pcclInt8},        {flagcxUint8, pcclUint8},
@@ -48,7 +51,7 @@ flagcxResult_t pcclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)p2f_ret_map[pcclGetVersion(version)];
 }
 
-flagcxResult_t pcclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t pcclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -73,7 +76,7 @@ flagcxResult_t pcclAdaptorGetStagedBuffer(const flagcxInnerComm_t comm,
 
 // Communicator functions
 flagcxResult_t pcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/ppu_nccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/ppu_nccl_adaptor.cc
@@ -6,11 +6,14 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(ncclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "ncclUniqueId does not fit inside flagcxInnerUniqueId");
+
 flagcxResult_t ppuncclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)ncclGetVersion(version);
 }
 
-flagcxResult_t ppuncclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t ppuncclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -33,7 +36,7 @@ const char *ppuncclAdaptorGetLastError(flagcxInnerComm_t comm) {
 
 flagcxResult_t
 ppuncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                           flagcxUniqueId_t commId, int rank,
+                           flagcxInnerUniqueId_t commId, int rank,
                            struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/rccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/rccl_adaptor.cc
@@ -6,11 +6,14 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(ncclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "ncclUniqueId does not fit inside flagcxInnerUniqueId");
+
 flagcxResult_t rcclAdaptorGetVersion(int *version) {
   return (flagcxResult_t)ncclGetVersion(version);
 }
 
-flagcxResult_t rcclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t rcclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -32,7 +35,7 @@ const char *rcclAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t rcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/tccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/tccl_adaptor.cc
@@ -9,6 +9,9 @@
 #include <cstring>
 #include <map>
 
+static_assert(sizeof(tcclUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "tcclUniqueId does not fit inside flagcxInnerUniqueId");
+
 static const std::map<tcclResult_t, flagcxResult_t> tcclToFlagcxResultMap = {
     {tcclSuccess, flagcxSuccess},
     {tcclUnhandledDeviceError, flagcxUnhandledDeviceError},
@@ -71,7 +74,7 @@ flagcxResult_t tcclAdaptorGetVersion(int *version) {
   return fromTcclResult(result);
 }
 
-flagcxResult_t tcclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t tcclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -98,7 +101,7 @@ const char *tcclAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t tcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/ccl/xccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/xccl_adaptor.cc
@@ -7,6 +7,9 @@
 #include "alloc.h"
 #include "comm.h"
 
+static_assert(sizeof(int) + sizeof(BKCLUniqueId) <= sizeof(flagcxInnerUniqueId),
+              "BKCLUniqueId does not fit inside flagcxInnerUniqueId");
+
 BKCLDataType flagcxToXcclDataType(flagcxDataType_t type) {
   // use BKCL_UINT8 as unknown data type
   static const struct {
@@ -58,7 +61,7 @@ flagcxResult_t xcclAdaptorGetVersion(int *version) {
   return flagcxNotSupported;
 }
 
-flagcxResult_t xcclAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+flagcxResult_t xcclAdaptorGetUniqueId(flagcxInnerUniqueId_t *uniqueId) {
   if (*uniqueId == NULL) {
     flagcxCalloc(uniqueId, 1);
   }
@@ -85,7 +88,7 @@ const char *xcclAdaptorGetLastError(flagcxInnerComm_t comm) {
 }
 
 flagcxResult_t xcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
+                                       flagcxInnerUniqueId_t commId, int rank,
                                        struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);

--- a/flagcx/adaptor/include/flagcx_ccl_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_ccl_adaptor.h
@@ -6,6 +6,7 @@
 #define FLAGCX_CCL_ADAPTOR_H_
 
 #include "flagcx.h"
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,8 +16,17 @@ extern "C" {
 // (flagcxStream_t, flagcxWindow_t are already typedef'd in flagcx.h)
 typedef struct flagcxInnerComm *flagcxInnerComm_t;
 typedef struct flagcxInnerDevComm *flagcxInnerDevComm_t;
-struct flagcxDevCommRequirements;
+typedef struct flagcxDevCommRequirements flagcxDevCommRequirements;
 struct bootstrapState;
+
+// Private storage for native communicator identifiers. This accommodates
+// CANN 9.0's 4108-byte HcclRootInfo without changing the public FlagCX ABI.
+#define FLAGCX_INNER_UNIQUE_ID_BYTES 4120
+typedef union {
+  char internal[FLAGCX_INNER_UNIQUE_ID_BYTES];
+  uint64_t alignment;
+} flagcxInnerUniqueId;
+typedef flagcxInnerUniqueId *flagcxInnerUniqueId_t;
 
 // Version history:
 //   v1 — 34 function pointers: getVersion, getUniqueId, getErrorString,
@@ -33,7 +43,7 @@ struct flagcxCCLAdaptor_v1 {
   const char *name;
   // Basic functions
   flagcxResult_t (*getVersion)(int *version);
-  flagcxResult_t (*getUniqueId)(flagcxUniqueId_t *uniqueId);
+  flagcxResult_t (*getUniqueId)(flagcxInnerUniqueId_t *uniqueId);
   const char *(*getErrorString)(flagcxResult_t result);
   const char *(*getLastError)(flagcxInnerComm_t comm);
   flagcxResult_t (*getStagedBuffer)(const flagcxInnerComm_t comm, void **buff,
@@ -41,7 +51,7 @@ struct flagcxCCLAdaptor_v1 {
 
   // Communicator functions
   flagcxResult_t (*commInitRank)(flagcxInnerComm_t *comm, int nranks,
-                                 flagcxUniqueId *commId, int rank,
+                                 flagcxInnerUniqueId *commId, int rank,
                                  struct bootstrapState *bootstrap);
   flagcxResult_t (*commFinalize)(flagcxInnerComm_t comm);
   flagcxResult_t (*commDestroy)(flagcxInnerComm_t comm);
@@ -117,7 +127,7 @@ struct flagcxCCLAdaptor_latest {
   const char *name;
   // Basic functions
   flagcxResult_t (*getVersion)(int *version);
-  flagcxResult_t (*getUniqueId)(flagcxUniqueId_t *uniqueId);
+  flagcxResult_t (*getUniqueId)(flagcxInnerUniqueId_t *uniqueId);
   const char *(*getErrorString)(flagcxResult_t result);
   const char *(*getLastError)(flagcxInnerComm_t comm);
   flagcxResult_t (*getStagedBuffer)(const flagcxInnerComm_t comm, void **buff,
@@ -125,7 +135,7 @@ struct flagcxCCLAdaptor_latest {
 
   // Communicator functions
   flagcxResult_t (*commInitRank)(flagcxInnerComm_t *comm, int nranks,
-                                 flagcxUniqueId *commId, int rank,
+                                 flagcxInnerUniqueId *commId, int rank,
                                  struct bootstrapState *bootstrap);
   flagcxResult_t (*commFinalize)(flagcxInnerComm_t comm);
   flagcxResult_t (*commDestroy)(flagcxInnerComm_t comm);

--- a/flagcx/core/flagcx_tuner.cc
+++ b/flagcx/core/flagcx_tuner.cc
@@ -407,8 +407,7 @@ flagcxCreateOrReplaceHomoComm(flagcxComm_t *comm,
   }
 
   flagcxInnerComm_t innerComm = NULL;
-  FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
-                                 (struct bootstrapState *)(ctx->bootstrap),
+  FLAGCXCHECK(flagcxHomoCommInit((struct bootstrapState *)(ctx->bootstrap),
                                  *comm, &innerComm));
   // Store new communicator of collCat into homoCommMap
   (*comm)->homoCommMap[collCat] = innerComm;
@@ -666,8 +665,7 @@ flagcxResult_t flagcxTunerSwitchCommConfig(void *context, flagcxComm_t *comm,
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commDestroy(inner));
       FLAGCXCHECK(setEnvConfig(cfg, FLAGCX_ENV_TYPE_CREATION));
       flagcxInnerComm_t newInner = NULL;
-      FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
-                                     (struct bootstrapState *)(ctx->bootstrap),
+      FLAGCXCHECK(flagcxHomoCommInit((struct bootstrapState *)(ctx->bootstrap),
                                      *comm, &newInner));
       (*comm)->tunerInnerComm = newInner;
       (*comm)->homoComm = newInner;
@@ -709,8 +707,7 @@ flagcxResult_t flagcxTunerSwitchCommConfig(void *context, flagcxComm_t *comm,
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commDestroy(inner));
       FLAGCXCHECK(setEnvConfig(cfg, FLAGCX_ENV_TYPE_CREATION));
       flagcxInnerComm_t newInner = NULL;
-      FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
-                                     (struct bootstrapState *)(ctx->bootstrap),
+      FLAGCXCHECK(flagcxHomoCommInit((struct bootstrapState *)(ctx->bootstrap),
                                      *comm, &newInner));
       (*comm)->tunerInnerComm = newInner;
       (*comm)->homoComm = newInner;

--- a/flagcx/core/include/global_comm.h
+++ b/flagcx/core/include/global_comm.h
@@ -107,11 +107,9 @@ struct flagcxComm {
   std::map<struct TunerCollCategory, flagcxInnerComm_t>
       homoBestCommMap;              // key: commTag returned by tuner
   flagcxInnerComm_t tunerInnerComm; // innerComm selected by tuner
-  flagcxUniqueId_t commId;
-  flagcxUniqueId *uniqueIdData;
-  bool isTuningWithFlagscale; // whether tuning with flagscale
-  bool isTunningComm;         // whether tuning the communicator
-  bool isUseSingleTunerComm;  // whether tuning with one communicator
+  bool isTuningWithFlagscale;       // whether tuning with flagscale
+  bool isTunningComm;               // whether tuning the communicator
+  bool isUseSingleTunerComm;        // whether tuning with one communicator
   struct C2cSchedulePair {
     int sendCluster;
     int recvCluster;
@@ -142,9 +140,7 @@ struct flagcxComm {
 
 // Function helps init single homo cluster.
 // return homoComm via homoComm parameter.
-flagcxResult_t flagcxHomoCommInit(flagcxUniqueId_t commId,
-                                  flagcxUniqueId *uniqueIdData,
-                                  struct bootstrapState *state,
+flagcxResult_t flagcxHomoCommInit(struct bootstrapState *state,
                                   flagcxComm_t comm,
                                   flagcxInnerComm_t *homoComm /*out*/);
 

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <unordered_map>
+#include <vector>
 
 flagcxRegPool globalRegPool;
 
@@ -1876,27 +1877,64 @@ static flagcxResult_t flagcxDevCommStateDestroy(flagcxComm_t comm) {
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxHomoCommInit(flagcxUniqueId_t commId,
-                                  flagcxUniqueId *uniqueIdData,
-                                  struct bootstrapState *state,
+static flagcxResult_t flagcxCollectUniqueIdResult(struct bootstrapState *state,
+                                                  int rank, int nranks,
+                                                  flagcxResult_t localResult) {
+  std::vector<flagcxResult_t> resultData(nranks, flagcxSuccess);
+  resultData[rank] = localResult;
+  FLAGCXCHECK(bootstrapCollAllGather(state, (void *)resultData.data(),
+                                     sizeof(flagcxResult_t)));
+  FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
+
+  for (int peer = 0; peer < nranks; peer++) {
+    if (resultData[peer] != flagcxSuccess) {
+      return resultData[peer];
+    }
+  }
+  return flagcxSuccess;
+}
+
+static flagcxResult_t flagcxBuildHomoRankList(flagcxComm_t comm,
+                                              std::vector<int> &globalRanks) {
+  globalRanks.assign(comm->homoRanks, -1);
+  int clusterId = comm->clusterIds[comm->rank];
+  for (int globalRank = 0; globalRank < comm->nranks; globalRank++) {
+    if (comm->clusterIds[globalRank] != clusterId) {
+      continue;
+    }
+    int homoRank = comm->globalRank2HomoRank[globalRank];
+    if (homoRank < 0 || homoRank >= comm->homoRanks ||
+        globalRanks[homoRank] != -1) {
+      return flagcxInternalError;
+    }
+    globalRanks[homoRank] = globalRank;
+  }
+  for (int globalRank : globalRanks) {
+    if (globalRank == -1) {
+      return flagcxInternalError;
+    }
+  }
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxHomoCommInit(struct bootstrapState *state,
                                   flagcxComm_t comm,
                                   flagcxInnerComm_t *homoComm /*out*/) {
   int rank = comm->rank;
   int nranks = comm->nranks;
-  memset((void *)commId, 0, sizeof(*commId));
-  memset((void *)uniqueIdData, 0, nranks * sizeof(flagcxUniqueId));
-  if (comm->homoRank == 0) {
-    cclAdaptors[flagcxCCLAdaptorDevice]->getUniqueId(&commId);
+  flagcxInnerUniqueId commIdStorage = {};
+  flagcxInnerUniqueId_t commId = &commIdStorage;
+  std::vector<int> homoGlobalRanks;
+  flagcxResult_t uniqueIdResult =
+      flagcxBuildHomoRankList(comm, homoGlobalRanks);
+  if (uniqueIdResult == flagcxSuccess && comm->homoRank == 0) {
+    uniqueIdResult = cclAdaptors[flagcxCCLAdaptorDevice]->getUniqueId(&commId);
   }
-  if (comm->homoRank == 0) {
-    memcpy((void *)&uniqueIdData[rank], (void *)commId, sizeof(flagcxUniqueId));
-  }
-  FLAGCXCHECK(bootstrapCollAllGather(state, (void *)uniqueIdData,
-                                     sizeof(flagcxUniqueId)));
-  FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
+  FLAGCXCHECK(flagcxCollectUniqueIdResult(state, rank, nranks, uniqueIdResult));
 
-  memcpy((void *)commId, (void *)&uniqueIdData[comm->homoRootRank],
-         sizeof(flagcxUniqueId));
+  FLAGCXCHECK(bootstrapCollSubgroupBroadcast(state, homoGlobalRanks.data(),
+                                             comm->homoRank, comm->homoRanks, 0,
+                                             (void *)commId, sizeof(*commId)));
   FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commInitRank(
       homoComm, comm->homoRanks, commId, comm->homoRank, NULL));
   return flagcxSuccess;
@@ -2108,9 +2146,6 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     (*comm)->hasSingleRankHomoComm = 0;
   }
 
-  flagcxUniqueId *uniqueIdData;
-  FLAGCXCHECK(flagcxCalloc(&uniqueIdData, nranks));
-
   // Tuner init
   bool useTuner = false;
   const char *useTunerEnv = flagcxGetEnv("FLAGCX_USE_TUNER");
@@ -2120,9 +2155,6 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
   INFO(FLAGCX_INIT, "Flagcx USE_TUNER flag set to %d", useTuner);
   if (useTuner) {
     (*comm)->tuner = &internalTuner;
-    FLAGCXCHECK(flagcxCalloc(&(*comm)->commId, 1));
-    memcpy((*comm)->commId, commId, sizeof(flagcxUniqueId));
-    (*comm)->uniqueIdData = uniqueIdData;
     (*comm)->tunerInnerComm = NULL;
     (*comm)->isTunningComm = false;
     (*comm)->isTuningWithFlagscale = false;
@@ -2171,8 +2203,7 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
              nConfigs);
 
         flagcxInnerComm_t innerComm = NULL;
-        FLAGCXCHECK(
-            flagcxHomoCommInit(commId, uniqueIdData, state, *comm, &innerComm));
+        FLAGCXCHECK(flagcxHomoCommInit(state, *comm, &innerComm));
         // Insert item into commMap
         (*comm)->commMap[tag] = innerComm;
         // For backward compatible, also assign homo_comm field.
@@ -2183,8 +2214,7 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     if (isTuningWithFlagscale) {
       // Create a default communicator based on the default config
       flagcxInnerComm_t innerComm = NULL;
-      FLAGCXCHECK(
-          flagcxHomoCommInit(commId, uniqueIdData, state, *comm, &innerComm));
+      FLAGCXCHECK(flagcxHomoCommInit(state, *comm, &innerComm));
       // Insert item into homoCommMap
       (*comm)->tunerInnerComm = innerComm;
       // For backward compatible, also assign homoComm field.
@@ -2192,26 +2222,23 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     }
   } else {
     (*comm)->tuner = NULL;
-    FLAGCXCHECK(flagcxHomoCommInit(commId, uniqueIdData, state, *comm,
-                                   &((*comm)->homoComm)));
+    FLAGCXCHECK(flagcxHomoCommInit(state, *comm, &((*comm)->homoComm)));
   }
 
   if (!useHomoComm(*comm) || useHeteroComm()) {
-    // Reset commId and hetero root rank calls flagcxHeteroGetUniqueId
-    memset((void *)commId, 0, sizeof(flagcxUniqueId));
-    memset((void *)uniqueIdData, 0, nranks * sizeof(flagcxUniqueId));
+    flagcxUniqueId heteroCommId = {};
+    flagcxResult_t uniqueIdResult = flagcxSuccess;
     if (rank == 0) {
-      flagcxHeteroGetUniqueId(commId);
-      memcpy((void *)&uniqueIdData[0], (void *)commId, sizeof(flagcxUniqueId));
+      uniqueIdResult = flagcxHeteroGetUniqueId(&heteroCommId);
     }
-    FLAGCXCHECK(bootstrapCollAllGather(state, (void *)uniqueIdData,
-                                       sizeof(flagcxUniqueId)));
-    FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
-
-    memcpy((void *)commId, (void *)&uniqueIdData[0], sizeof(flagcxUniqueId));
-    // call flagcxHeteroCommInitRank
     FLAGCXCHECK(
-        flagcxHeteroCommInitRank(&(*comm)->heteroComm, nranks, *commId, rank));
+        flagcxCollectUniqueIdResult(state, rank, nranks, uniqueIdResult));
+    FLAGCXCHECK(bootstrapCollBroadcast(
+        state, rank, nranks, 0, (void *)&heteroCommId, sizeof(heteroCommId)));
+
+    // call flagcxHeteroCommInitRank
+    FLAGCXCHECK(flagcxHeteroCommInitRank(&(*comm)->heteroComm, nranks,
+                                         heteroCommId, rank));
 
     // Share ipcTable with heteroComm for intra-node D2D bypass
     (*comm)->heteroComm->ipcTable = (*comm)->ipcTable;
@@ -2223,8 +2250,9 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
         FLAGCXCHECK((*comm)->heteroComm->netAdaptor->getProperties(
             (*comm)->heteroComm->netDev, bootstrapGetNetProperties()));
       }
+      flagcxInnerUniqueId hostCommId = {};
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorHost]->commInitRank(
-          &(*comm)->hostComm, nranks, commId, rank, state));
+          &(*comm)->hostComm, nranks, &hostCommId, rank, state));
     }
   }
 
@@ -2287,27 +2315,26 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
          (*comm)->homoInterRanks, (*comm)->hasSingleRankHomoComm);
 
     // Experimental for multi-nic support
-    // Reset commId and homo inter root rank calls underlying GetUniqueId
-    // function for initialization of homo inter communicator
-    memset((void *)commId, 0, sizeof(flagcxUniqueId));
-    memset((void *)uniqueIdData, 0, nranks * sizeof(flagcxUniqueId));
+    flagcxInnerUniqueId homoInterCommIdStorage = {};
+    flagcxInnerUniqueId_t homoInterCommId = &homoInterCommIdStorage;
     // Let homoInterRootRank call underlying GetUniqueId function
     // for initialization of homo inter communicator
+    flagcxResult_t uniqueIdResult = flagcxSuccess;
     if (rank == (*comm)->homoInterRootRank) {
-      cclAdaptors[flagcxCCLAdaptorDevice]->getUniqueId(&commId);
-      memcpy((void *)&uniqueIdData[rank], (void *)commId,
-             sizeof(flagcxUniqueId));
+      uniqueIdResult =
+          cclAdaptors[flagcxCCLAdaptorDevice]->getUniqueId(&homoInterCommId);
     }
-    // Collect uniqueIdData globally
-    FLAGCXCHECK(bootstrapCollAllGather(state, (void *)uniqueIdData,
-                                       sizeof(flagcxUniqueId)));
-    FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
+    FLAGCXCHECK(
+        flagcxCollectUniqueIdResult(state, rank, nranks, uniqueIdResult));
+
     // Call cclAdaptor->commInitRank
     if ((*comm)->homoInterRootRank != -1) {
-      memcpy((void *)commId, (void *)&uniqueIdData[(*comm)->homoInterRootRank],
-             sizeof(flagcxUniqueId));
+      FLAGCXCHECK(bootstrapCollSubgroupBroadcast(
+          state, myClusterInterRanks.data(), (*comm)->homoInterMyRank,
+          (*comm)->homoInterRanks, 0, (void *)homoInterCommId,
+          sizeof(*homoInterCommId)));
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commInitRank(
-          &(*comm)->homoInterComm, (*comm)->homoInterRanks, commId,
+          &(*comm)->homoInterComm, (*comm)->homoInterRanks, homoInterCommId,
           (*comm)->homoInterMyRank, NULL));
     }
     free(nicDistanceData);
@@ -2324,10 +2351,6 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
 
   free(clusterInterRankData);
   free(vendorData);
-  if (!useTuner) {
-    free(uniqueIdData);
-  }
-
   // Initialize custom op state (non-fatal if fails)
   FLAGCXCHECK(flagcxDevCommStateInit(*comm));
 
@@ -2411,9 +2434,6 @@ flagcxResult_t flagcxCommDestroy(flagcxComm_t comm) {
   // Destroy tuner
   if (comm->tuner) {
     comm->tuner->destroy(comm->tunerContext);
-    // Free uniqueIdData and commId
-    free(comm->uniqueIdData);
-    free(comm->commId);
   }
 
   // Finalize net adaptor plugin (dlclose)

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -771,6 +771,15 @@ flagcxResult_t bootstrapCollBroadcast(struct bootstrapState *state, int rank,
                                          bcastData, size);
 }
 
+flagcxResult_t
+bootstrapCollSubgroupBroadcast(struct bootstrapState *state, int *globalRanks,
+                               int subgroupRank, int subgroupSize,
+                               int subgroupRoot, void *bcastData, int size) {
+  return bootstrapCollIntraNodeBroadcast(state, globalRanks, subgroupRank,
+                                         subgroupSize, subgroupRoot, bcastData,
+                                         size);
+}
+
 // ============================================================================
 // Typed Collective Operations (Reduce, AllReduce, etc.)
 // ============================================================================

--- a/flagcx/service/include/bootstrap.h
+++ b/flagcx/service/include/bootstrap.h
@@ -110,6 +110,10 @@ flagcxResult_t bootstrapCollBarrier(struct bootstrapState *state, int rank,
 flagcxResult_t bootstrapCollBroadcast(struct bootstrapState *state, int rank,
                                       int nranks, int root, void *bcastData,
                                       int size);
+flagcxResult_t
+bootstrapCollSubgroupBroadcast(struct bootstrapState *state, int *globalRanks,
+                               int subgroupRank, int subgroupSize,
+                               int subgroupRoot, void *bcastData, int size);
 flagcxResult_t bootstrapCollIntraNodeBarrier(struct bootstrapState *state,
                                              int *ranks, int rank, int nranks,
                                              int tag);

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -54,8 +54,13 @@ class flagcxDevCommRequirements(ctypes.Structure):
         ("interCounterCount", ctypes.c_int),
     ]
 
+FLAGCX_UNIQUE_ID_BYTES = 256
+
+
 class flagcxUniqueId(ctypes.Structure):
-    _fields_ = [("internal", ctypes.c_byte * 256)]
+    _fields_ = [("internal", ctypes.c_byte * FLAGCX_UNIQUE_ID_BYTES)]
+
+
 flagcxUniqueId_t = ctypes.POINTER(flagcxUniqueId)
 
 DEVICE_SYNCHRONIZE_FUNCTYPE = ctypes.CFUNCTYPE(flagcxResult_t)
@@ -548,18 +553,20 @@ class FLAGCXLibrary:
         """
         Reconstructs a flagcxUniqueId object from bytes data.
         Args:
-            data: Must be a 256-byte data block (matching FlagCX's unique_id).
+            data: Must match the size of FlagCX's unique_id.
         Returns:
             flagcxUniqueId: The reconstructed FlagCX Unique ID object.
         Raises:
-            ValueError: If the input data length is not 256 bytes.
+            ValueError: If the input data length does not match unique_id.
         """
-        if len(data) != 256:
+        if len(data) != FLAGCX_UNIQUE_ID_BYTES:
             raise ValueError(
-                f"Expected 256 bytes for ncclUniqueId, got {len(data)} bytes")
+                f"Expected {FLAGCX_UNIQUE_ID_BYTES} bytes for flagcxUniqueId, "
+                f"got {len(data)} bytes")
 
         unique_id = flagcxUniqueId()
-        ctypes.memmove(ctypes.addressof(unique_id.internal), data, 256)
+        ctypes.memmove(ctypes.addressof(unique_id.internal), data,
+                       FLAGCX_UNIQUE_ID_BYTES)
         return unique_id
 
     def flagcxCommInitRank(self, world_size: int, unique_id: flagcxUniqueId,
@@ -889,6 +896,7 @@ class FLAGCXLibrary:
 
 
 __all__ = [
-    "FLAGCXLibrary", "flagcxDataTypeEnum", "flagcxRedOpTypeEnum", "flagcxUniqueId",
-    "flagcxDeviceHandle_t", "flagcxComm_t", "flagcxStream_t", "flagcxEvent_t", "buffer_type"
+    "FLAGCX_UNIQUE_ID_BYTES", "FLAGCXLibrary", "flagcxDataTypeEnum",
+    "flagcxRedOpTypeEnum", "flagcxUniqueId", "flagcxDeviceHandle_t",
+    "flagcxComm_t", "flagcxStream_t", "flagcxEvent_t", "buffer_type"
 ]

--- a/plugin/interservice/test_flagcx_wrapper.py
+++ b/plugin/interservice/test_flagcx_wrapper.py
@@ -1,0 +1,32 @@
+import ctypes
+import unittest
+
+from plugin.interservice.flagcx_wrapper import (
+    FLAGCX_UNIQUE_ID_BYTES,
+    FLAGCXLibrary,
+    flagcxUniqueId,
+)
+
+
+class FlagcxUniqueIdTest(unittest.TestCase):
+    def test_size_matches_public_abi(self):
+        self.assertEqual(FLAGCX_UNIQUE_ID_BYTES, 256)
+        self.assertEqual(ctypes.sizeof(flagcxUniqueId), FLAGCX_UNIQUE_ID_BYTES)
+
+    def test_round_trip_preserves_public_id(self):
+        data = bytes(i % 256 for i in range(FLAGCX_UNIQUE_ID_BYTES))
+
+        unique_id = FLAGCXLibrary.unique_id_from_bytes(None, data)
+
+        round_trip = bytes(unique_id.internal)
+        self.assertEqual(round_trip, data)
+
+    def test_rejects_incorrect_sizes(self):
+        for size in (FLAGCX_UNIQUE_ID_BYTES - 1, FLAGCX_UNIQUE_ID_BYTES + 1):
+            with self.subTest(size=size):
+                with self.assertRaisesRegex(ValueError, str(size)):
+                    FLAGCXLibrary.unique_id_from_bytes(None, bytes(size))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin/interservice/test_triton_lsa.py
+++ b/plugin/interservice/test_triton_lsa.py
@@ -26,6 +26,7 @@ from torch.cuda.memory import CUDAPluggableAllocator
 from torch.utils.cpp_extension import load_inline
 
 from flagcx_wrapper import (
+    FLAGCX_UNIQUE_ID_BYTES,
     FLAGCXLibrary,
     flagcxDevCommRequirements,
     flagcxUniqueId,
@@ -237,7 +238,7 @@ def main():
         unique_id = flagcx.flagcxGetUniqueId()
         id_bytes = bytes(unique_id.internal)
     else:
-        id_bytes = b"\x00" * 256
+        id_bytes = b"\x00" * FLAGCX_UNIQUE_ID_BYTES
 
     # Broadcast unique_id bytes via torch distributed
     id_tensor = torch.frombuffer(bytearray(id_bytes), dtype=torch.uint8).cuda()

--- a/test/unittest/service/test_unique_id.cpp
+++ b/test/unittest/service/test_unique_id.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include "flagcx.h"
+#include "flagcx_ccl_adaptor.h"
+
+namespace {
+
+constexpr size_t kCann90HcclRootInfoBytes = 4108;
+
+static_assert(sizeof(flagcxUniqueId) == FLAGCX_UNIQUE_ID_BYTES,
+              "flagcxUniqueId size must match FLAGCX_UNIQUE_ID_BYTES");
+static_assert(sizeof(flagcxInnerUniqueId) == FLAGCX_INNER_UNIQUE_ID_BYTES,
+              "flagcxInnerUniqueId size must match its capacity macro");
+static_assert(sizeof(flagcxInnerUniqueId) >= kCann90HcclRootInfoBytes,
+              "flagcxInnerUniqueId must accommodate CANN 9.0 HcclRootInfo");
+static_assert(alignof(flagcxInnerUniqueId) >= alignof(uint64_t),
+              "flagcxInnerUniqueId must support aligned native ID casts");
+
+TEST(UniqueId, KeepsPublicAbiAndAccommodatesCannInternally) {
+  EXPECT_EQ(sizeof(flagcxUniqueId), 256u);
+  EXPECT_EQ(sizeof(flagcxInnerUniqueId), 4120u);
+  EXPECT_GE(sizeof(flagcxInnerUniqueId), kCann90HcclRootInfoBytes);
+  EXPECT_GE(alignof(flagcxInnerUniqueId), alignof(uint64_t));
+}
+
+} // namespace


### PR DESCRIPTION
### PR Category
CRL

### PR Types
Bug Fixes

### PR Description
This PR fixes a latent buffer-overflow risk in homogeneous communicator initialization. The public flagcxUniqueId is only 256 bytes, but vendor native root-info structures can be much larger — notably CANN 9.0's HcclRootInfo is 4108 bytes. Previously the code cast the 256-byte public id into these larger native structures (via getUniqueId/commInitRank), overflowing the buffer. The fix introduces a private 4120-byte flagcxInnerUniqueId union used only across the internal CCL adaptor boundary, while keeping the public 256-byte ABI unchanged. It also refactors unique-id exchange to broadcast within homogeneous subgroups (instead of a global all-gather of per-rank ids), and propagates getUniqueId result codes.