### PR TITLE
[CRL] Clean up failed communicator creation

### DIFF
--- a/.github/configs/cuda.yml
+++ b/.github/configs/cuda.yml
@@ -22,6 +22,7 @@ unit_test_suites:
   - adaptor
   - core
   - device_api
+  - device_api_host
   - device_api_unified_ir
   - p2p
   - rma

--- a/.github/scripts/ci/run_unit_test.sh
+++ b/.github/scripts/ci/run_unit_test.sh
@@ -232,6 +232,7 @@ run_suite() {
       bash "$PROJECT_ROOT/test/script/symmem_test.sh"
       ;;
     device_api)
+      make -C "$suite_dir" run-unit "${args[@]}"
       run_device_api
       ;;
     device_api_unified_ir)
@@ -245,9 +246,7 @@ run_suite() {
 }
 
 case "$SUITE" in
-  device_api|device_api_unified_ir)
-    ;;
-  adaptor|core|p2p|rma|runner|service|symmem)
+  adaptor|core|device_api|device_api_unified_ir|p2p|rma|runner|service|symmem)
     build_googletest
     ;;
   *)

--- a/.github/scripts/ci/run_unit_test.sh
+++ b/.github/scripts/ci/run_unit_test.sh
@@ -56,7 +56,8 @@ build_project() {
 
 build_suite() {
   local suite_dir="$PROJECT_ROOT/test/unittest/$SUITE"
-  if [[ "$SUITE" == device_api_unified_ir ]]; then
+  if [[ "$SUITE" == device_api_host ||
+        "$SUITE" == device_api_unified_ir ]]; then
     suite_dir="$PROJECT_ROOT/test/unittest/device_api"
   fi
   local -a args=("${FLAGCX_CI_TEST_MAKE_ARGS[@]}")
@@ -69,7 +70,20 @@ build_suite() {
     fi
   fi
 
-  make -C "$suite_dir" --jobs="$(nproc)" "${args[@]}"
+  if [[ "$SUITE" == device_api_host ]]; then
+    make -C "$suite_dir" --jobs="$(nproc)" unit "${args[@]}"
+  elif [[ "$SUITE" == device_api ||
+          "$SUITE" == device_api_unified_ir ]]; then
+    make -C "$suite_dir" --jobs="$(nproc)" mpi "${args[@]}"
+  else
+    make -C "$suite_dir" --jobs="$(nproc)" "${args[@]}"
+  fi
+}
+
+run_device_api_host() {
+  local suite_dir="$PROJECT_ROOT/test/unittest/device_api"
+  local -a args=("${FLAGCX_CI_TEST_MAKE_ARGS[@]}")
+  make -C "$suite_dir" run-unit "${args[@]}"
 }
 
 run_device_api() {
@@ -190,6 +204,10 @@ run_device_api_unified_ir() {
 
 run_suite() {
   local suite_dir="$PROJECT_ROOT/test/unittest/$SUITE"
+  if [[ "$SUITE" == device_api_host ||
+        "$SUITE" == device_api_unified_ir ]]; then
+    suite_dir="$PROJECT_ROOT/test/unittest/device_api"
+  fi
   local -a args=("${FLAGCX_CI_TEST_MAKE_ARGS[@]}")
 
   if declare -F flagcx_ci_run_suite_override >/dev/null; then
@@ -232,8 +250,10 @@ run_suite() {
       bash "$PROJECT_ROOT/test/script/symmem_test.sh"
       ;;
     device_api)
-      make -C "$suite_dir" run-unit "${args[@]}"
       run_device_api
+      ;;
+    device_api_host)
+      run_device_api_host
       ;;
     device_api_unified_ir)
       run_device_api_unified_ir
@@ -246,8 +266,10 @@ run_suite() {
 }
 
 case "$SUITE" in
-  adaptor|core|device_api|device_api_unified_ir|p2p|rma|runner|service|symmem)
+  adaptor|core|device_api_host|p2p|rma|runner|service|symmem)
     build_googletest
+    ;;
+  device_api|device_api_unified_ir)
     ;;
   *)
     echo "Unsupported unit test suite: $SUITE" >&2

--- a/.github/scripts/set_env/cuda.sh
+++ b/.github/scripts/set_env/cuda.sh
@@ -49,9 +49,9 @@ flagcx_ci_configure_suite() {
     runner)
       FLAGCX_CI_PROJECT_MAKE_ARGS+=(COMPILE_KERNEL=1)
       ;;
-    device_api|device_api_unified_ir)
+    device_api|device_api_host|device_api_unified_ir)
       FLAGCX_CI_PROJECT_MAKE_ARGS+=(COMPILE_KERNEL=1 FORCE_DEFAULT_PATH=1)
-      FLAGCX_CI_TEST_MAKE_ARGS+=(FORCE_DEFAULT_PATH=1)
+      FLAGCX_CI_TEST_MAKE_ARGS+=(COMPILE_KERNEL=1 FORCE_DEFAULT_PATH=1)
       ;;
   esac
 }

--- a/flagcx/adaptor/device_api/default_dev_api_backend.cc
+++ b/flagcx/adaptor/device_api/default_dev_api_backend.cc
@@ -53,6 +53,18 @@ static void shmHostUnregister(void *ptr) {
     deviceAdaptor->hostUnregister(ptr);
 }
 
+static bool
+registrationMatchesBuffer(flagcxComm_t comm,
+                          const struct flagcxOneSideHandleInfo *registration,
+                          const void *buffer) {
+  if (comm == nullptr || comm->heteroComm == nullptr ||
+      registration == nullptr || registration->baseVas == nullptr ||
+      comm->rank < 0 || comm->rank >= comm->heteroComm->nRanks) {
+    return false;
+  }
+  return registration->baseVas[comm->rank] == (uintptr_t)buffer;
+}
+
 // ==========================================================================
 // Inter-node signal relay setup
 // ==========================================================================
@@ -161,19 +173,21 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
 
   if (flagcxParamSignalHostEnable() == 0) {
     // ── IPC device memory path (default) ─────────────────────────────────
-    void *barrierFlags = nullptr;
-    FLAGCXCHECK(deviceAdaptor->deviceMalloc(&barrierFlags, barrierSize,
-                                            flagcxMemDevice, NULL));
-    FLAGCXCHECK(deviceAdaptor->deviceMemset(barrierFlags, 0, barrierSize,
-                                            flagcxMemDevice, NULL));
-    devComm->localBarrierFlags = (uint64_t *)barrierFlags;
+    flagcxResult_t res =
+        deviceAdaptor->deviceMalloc((void **)&devComm->localBarrierFlags,
+                                    barrierSize, flagcxMemDevice, NULL);
+    if (res != flagcxSuccess)
+      return res;
+    devComm->localBarrierFlagsDeviceAllocated = true;
+    res = deviceAdaptor->deviceMemset(devComm->localBarrierFlags, 0,
+                                      barrierSize, flagcxMemDevice, NULL);
+    if (res != flagcxSuccess)
+      return res;
 
-    int slot = buildIpcPeerPointers(comm, barrierFlags, barrierSize);
-    if (slot < 0) {
-      deviceAdaptor->deviceFree(barrierFlags, flagcxMemDevice, NULL);
-      devComm->localBarrierFlags = nullptr;
+    int slot =
+        buildIpcPeerPointers(comm, devComm->localBarrierFlags, barrierSize);
+    if (slot < 0)
       return flagcxSystemError;
-    }
 
     devComm->barrierPeers = (uint64_t **)comm->ipcTable[slot].devPeerPtrs;
     devComm->barrierIpcIndex = slot;
@@ -186,8 +200,8 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
     INFO(FLAGCX_INIT,
          "setupIpcBarriers(IPC): rank %d slot %d localBarrierFlags=%p "
          "barrierPeers=%p nBarriers=%d",
-         myRank, slot, barrierFlags, (void *)devComm->barrierPeers,
-         devComm->nBarriers);
+         myRank, slot, (void *)devComm->localBarrierFlags,
+         (void *)devComm->barrierPeers, devComm->nBarriers);
 
   } else {
     // ── flagcxShm + hipHostRegister path (FLAGCX_SIGNAL_HOST_ENABLE=1) ──
@@ -197,6 +211,7 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
     void **devPeerPtrs = nullptr;
     void *myDevPtr = nullptr;
     void **hostDevPtrs = nullptr;
+    int registeredPeerCount = 0;
 
     char myShmPath[SHM_PATH_MAX];
     snprintf(myShmPath, sizeof(myShmPath), "/dev/shm/flagcx_barrier_%016llx_%d",
@@ -215,15 +230,13 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
         res, fail_own_shm);
 
     // Step 3: Map peer shm segments.
-    peerCpuPtrs = (void **)malloc(localRanks * sizeof(void *));
+    peerCpuPtrs = (void **)calloc(localRanks, sizeof(void *));
     peerShmHandles =
-        (flagcxShmHandle_t *)malloc(localRanks * sizeof(flagcxShmHandle_t));
+        (flagcxShmHandle_t *)calloc(localRanks, sizeof(flagcxShmHandle_t));
     if (!peerCpuPtrs || !peerShmHandles) {
       res = flagcxSystemError;
       goto fail_peer_shm;
     }
-    memset(peerCpuPtrs, 0, localRanks * sizeof(void *));
-    memset(peerShmHandles, 0, localRanks * sizeof(flagcxShmHandle_t));
 
     for (int lr = 0; lr < localRanks; lr++) {
       int globalR = comm->localRankToRank[lr];
@@ -254,6 +267,7 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
     for (int lr = 0; lr < localRanks; lr++) {
       FLAGCXCHECKGOTO(shmHostRegister(peerCpuPtrs[lr], barrierSize), res,
                       fail_peer_shm);
+      registeredPeerCount++;
       FLAGCXCHECKGOTO(deviceAdaptor->hostGetDevicePointer(&hostDevPtrs[lr],
                                                           peerCpuPtrs[lr]),
                       res, fail_peer_shm);
@@ -277,6 +291,7 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
     devComm->barrierIpcIndex = -1;
     devComm->localBarrierShmPtr = myCpuPtr;
     devComm->peerBarrierShmPtrs = peerCpuPtrs;
+    devComm->registeredBarrierShmCount = registeredPeerCount;
     devComm->barrierShmSize = barrierSize;
     devComm->barrierDevPeerPtrsRaw = (uint64_t **)devPeerPtrs;
     devComm->myShmHandle = myShmHandle;
@@ -293,12 +308,9 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
     return flagcxSuccess;
 
   fail_peer_shm:
-    if (hostDevPtrs) {
-      for (int lr = 0; lr < localRanks; lr++)
-        if (peerCpuPtrs && peerCpuPtrs[lr])
-          shmHostUnregister(peerCpuPtrs[lr]);
-      free(hostDevPtrs);
-    }
+    for (int lr = 0; lr < registeredPeerCount; lr++)
+      shmHostUnregister(peerCpuPtrs[lr]);
+    free(hostDevPtrs);
     if (devPeerPtrs)
       deviceAdaptor->deviceFree(devPeerPtrs, flagcxMemDevice, NULL);
     if (peerShmHandles) {
@@ -519,6 +531,8 @@ defaultDevApiCommCreate(flagcxComm_t comm,
 
       // Register signal buffer for RDMA one-sided access
       if (devComm->signalBuffer) {
+        struct flagcxOneSideHandleInfo *previousRegistration =
+            comm->heteroComm->signalHandle;
         int sigPtrType =
             flagcxParamSignalHostEnable() ? FLAGCX_PTR_HOST : FLAGCX_PTR_CUDA;
         INFO(FLAGCX_INIT,
@@ -528,11 +542,18 @@ defaultDevApiCommCreate(flagcxComm_t comm,
                                           (size_t)devComm->signalCount *
                                               bufCtxCount * sizeof(uint64_t),
                                           sigPtrType);
-        if (res != flagcxSuccess || comm->heteroComm->signalHandle == nullptr) {
+        struct flagcxOneSideHandleInfo *registration =
+            comm->heteroComm->signalHandle;
+        if (res != flagcxSuccess ||
+            !registrationMatchesBuffer(comm, registration,
+                                       devComm->signalBuffer)) {
           WARN("defaultDevApiCommCreate: flagcxOneSideSignalRegister failed "
-               "(%d, handle=%p)",
-               res, (void *)comm->heteroComm->signalHandle);
+               "or returned a registration for another buffer "
+               "(%d, handle=%p, buffer=%p)",
+               res, (void *)registration, (void *)devComm->signalBuffer);
         } else {
+          if (previousRegistration == nullptr)
+            devComm->ownedSignalRegistration = registration;
           devComm->netSignalReady = 1;
           INFO(FLAGCX_INIT, "defaultDevApiCommCreate: signalRegister OK");
         }
@@ -540,15 +561,24 @@ defaultDevApiCommCreate(flagcxComm_t comm,
 
       // Register staging buffer for PutValue RDMA source
       if (devComm->putValueStagingBuffer) {
+        struct flagcxOneSideHandleInfo *previousRegistration =
+            comm->heteroComm->stagingHandle;
         INFO(FLAGCX_INIT, "defaultDevApiCommCreate: registering stagingBuffer");
         res = flagcxOneSideStagingRegister(comm, devComm->putValueStagingBuffer,
                                            stagingSize);
+        struct flagcxOneSideHandleInfo *registration =
+            comm->heteroComm->stagingHandle;
         if (res != flagcxSuccess ||
-            comm->heteroComm->stagingHandle == nullptr) {
+            !registrationMatchesBuffer(comm, registration,
+                                       devComm->putValueStagingBuffer)) {
           WARN("defaultDevApiCommCreate: flagcxOneSideStagingRegister failed "
-               "(%d, handle=%p)",
-               res, (void *)comm->heteroComm->stagingHandle);
+               "or returned a registration for another buffer "
+               "(%d, handle=%p, buffer=%p)",
+               res, (void *)registration,
+               (void *)devComm->putValueStagingBuffer);
         } else {
+          if (previousRegistration == nullptr)
+            devComm->ownedStagingRegistration = registration;
           devComm->netPutValueReady = 1;
           INFO(FLAGCX_INIT, "defaultDevApiCommCreate: stagingRegister OK");
         }
@@ -639,6 +669,24 @@ defaultDevApiCommCreate(flagcxComm_t comm,
 
 static flagcxResult_t defaultDevApiCommDestroy(flagcxComm_t comm,
                                                flagcxDevComm_t devComm) {
+  // Deregister communicator-level MRs before freeing their backing buffers.
+  // Check handle identity so rollback cannot remove a registration owned by
+  // another DevComm.
+  if (devComm->ownedStagingRegistration) {
+    if (comm != nullptr && comm->heteroComm != nullptr &&
+        comm->heteroComm->stagingHandle == devComm->ownedStagingRegistration) {
+      flagcxOneSideStagingDeregister(comm);
+    }
+    devComm->ownedStagingRegistration = nullptr;
+  }
+  if (devComm->ownedSignalRegistration) {
+    if (comm != nullptr && comm->heteroComm != nullptr &&
+        comm->heteroComm->signalHandle == devComm->ownedSignalRegistration) {
+      flagcxOneSideSignalDeregister(comm);
+    }
+    devComm->ownedSignalRegistration = nullptr;
+  }
+
   // ── IPC slot: immediate full cleanup ──────────────────────────────────
   if (comm != nullptr && devComm->barrierIpcIndex >= 0 &&
       devComm->barrierIpcIndex < FLAGCX_MAX_IPC_ENTRIES) {
@@ -657,6 +705,7 @@ static flagcxResult_t defaultDevApiCommDestroy(flagcxComm_t comm,
     }
     e->inUse = false;
   }
+  devComm->barrierIpcIndex = -1;
 
   // ── P2P signal/counter IPC slot cleanup ─────────────────────────────────
   auto cleanupIpcSlot = [&](int slot) {
@@ -678,46 +727,51 @@ static flagcxResult_t defaultDevApiCommDestroy(flagcxComm_t comm,
     e->inUse = false;
   };
   cleanupIpcSlot(devComm->signalIpcSlot);
+  devComm->signalIpcSlot = -1;
 
   // ── Shm path cleanup (FLAGCX_SIGNAL_HOST_ENABLE=1 only) ──────────────
   if (devComm->peerBarrierShmPtrs) {
-    for (int lr = 0; lr < devComm->nLocalRanks; lr++) {
+    for (int lr = 0; lr < devComm->registeredBarrierShmCount; lr++) {
       if (devComm->peerBarrierShmPtrs[lr])
         shmHostUnregister(devComm->peerBarrierShmPtrs[lr]);
     }
     free(devComm->peerBarrierShmPtrs);
     devComm->peerBarrierShmPtrs = nullptr;
   }
-  if (devComm->localBarrierShmPtr) {
-    shmHostUnregister(devComm->localBarrierShmPtr);
-    // Close peer shm handles (skip own slot which equals myShmHandle)
-    if (devComm->peerShmHandles) {
-      for (int lr = 0; lr < devComm->nLocalRanks; lr++) {
-        if (devComm->peerShmHandles[lr] &&
-            devComm->peerShmHandles[lr] != devComm->myShmHandle)
-          flagcxShmClose(devComm->peerShmHandles[lr]);
+  devComm->registeredBarrierShmCount = 0;
+  // Close peer shm handles (skip own slot which aliases myShmHandle).
+  if (devComm->peerShmHandles) {
+    for (int lr = 0; lr < devComm->nLocalRanks; lr++) {
+      if (devComm->peerShmHandles[lr] &&
+          devComm->peerShmHandles[lr] != devComm->myShmHandle) {
+        flagcxShmClose(devComm->peerShmHandles[lr]);
       }
-      free(devComm->peerShmHandles);
-      devComm->peerShmHandles = nullptr;
     }
-    flagcxShmClose(devComm->myShmHandle);
-    devComm->localBarrierShmPtr = nullptr;
+    free(devComm->peerShmHandles);
+    devComm->peerShmHandles = nullptr;
   }
+  if (devComm->myShmHandle) {
+    flagcxShmClose(devComm->myShmHandle);
+    devComm->myShmHandle = nullptr;
+  }
+  devComm->localBarrierShmPtr = nullptr;
+  devComm->barrierShmSize = 0;
   if (devComm->barrierDevPeerPtrsRaw) {
     deviceAdaptor->deviceFree(devComm->barrierDevPeerPtrsRaw, flagcxMemDevice,
                               NULL);
     devComm->barrierDevPeerPtrsRaw = nullptr;
   }
-
-  // ── MR deregistration ────────────────────────────────────────────────
-  // (signal and staging MR are deregistered at comm level in commCleanup)
+  devComm->barrierPeers = nullptr;
 
   // ── Free one-sided buffers immediately ────────────────────────────────
   if (devComm->localBarrierFlags) {
-    deviceAdaptor->deviceFree(devComm->localBarrierFlags, flagcxMemDevice,
-                              NULL);
+    if (devComm->localBarrierFlagsDeviceAllocated) {
+      deviceAdaptor->deviceFree(devComm->localBarrierFlags, flagcxMemDevice,
+                                NULL);
+    }
     devComm->localBarrierFlags = nullptr;
   }
+  devComm->localBarrierFlagsDeviceAllocated = false;
   if (devComm->epochBuffer) {
     deviceAdaptor->deviceFree(devComm->epochBuffer, flagcxMemDevice, NULL);
     devComm->epochBuffer = nullptr;

--- a/flagcx/adaptor/device_api/dev_api_backend.h
+++ b/flagcx/adaptor/device_api/dev_api_backend.h
@@ -17,6 +17,8 @@ struct flagcxDevApiBackend {
   flagcxResult_t (*devCommCreate)(flagcxComm_t comm,
                                   const struct flagcxDevCommRequirements *reqs,
                                   flagcxDevComm_t devComm);
+  // Must accept a zero-initialized or partially-created devComm: the common
+  // lifecycle calls this function to roll back devCommCreate failures.
   flagcxResult_t (*devCommDestroy)(flagcxComm_t comm, flagcxDevComm_t devComm);
 
   // DevMem lifecycle

--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -68,6 +68,11 @@ flagcxDevCommCreate(flagcxComm_t comm, const flagcxDevCommRequirements *reqs,
     if (ret != flagcxSuccess) {
       WARN("flagcxDevCommCreate: %s backend failed (%d)", devApiBackend->name,
            ret);
+      flagcxResult_t cleanupRet = devApiBackend->devCommDestroy(comm, handle);
+      if (cleanupRet != flagcxSuccess) {
+        WARN("flagcxDevCommCreate: %s backend rollback failed (%d)",
+             devApiBackend->name, cleanupRet);
+      }
       pthread_mutex_destroy(&handle->cachedPtrMutex);
       free(handle);
       return ret;

--- a/flagcx/adaptor/include/device_api/flagcx_device_internal.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device_internal.h
@@ -21,6 +21,7 @@
 // Forward declaration for typed vendor device comm handle
 struct flagcxInnerDevComm;
 typedef struct flagcxInnerDevComm *flagcxInnerDevComm_t;
+struct flagcxOneSideHandleInfo;
 
 // ============================================================
 // Section 1: flagcxDevCommInternal — Host-Side Opaque Handle
@@ -50,15 +51,19 @@ struct flagcxDevCommInternal {
                           // epochs]
   int nBarriers;          // = FLAGCX_DEVICE_CTA_COUNT (needed in kernel)
   // Host-side cleanup bookkeeping (not passed to kernel)
+  bool localBarrierFlagsDeviceAllocated; // true only when localBarrierFlags is
+                                         // owned device memory, not an SHM
+                                         // device-visible alias
   int barrierIpcIndex;  // index into comm->ipcTable (-1 if no IPC barrier)
   int *localRankToRank; // intra-node rank mapping (for IPC exchange)
   int nLocalRanks;
   // flagcxShm barrier path (non-null when FLAGCX_SIGNAL_HOST_ENABLE=1)
-  void *localBarrierShmPtr;  // CPU VA of own shm mapping (hostUnregister +
-                             // flagcxShmClose)
+  void *localBarrierShmPtr;  // non-owning alias of this rank's entry in
+                             // peerBarrierShmPtrs
   void **peerBarrierShmPtrs; // CPU VA array [nLocalRanks] for each peer's shm
-                             // mapping (hostUnregister + flagcxShmClose)
-  size_t barrierShmSize;     // size in bytes (for hostUnregister)
+                             // mapping; owns each successful host registration
+  int registeredBarrierShmCount;     // registered prefix of peerBarrierShmPtrs
+  size_t barrierShmSize;             // size in bytes (for hostUnregister)
   uint64_t **barrierDevPeerPtrsRaw;  // standalone device array (deviceFree; shm
                                      // path only)
   flagcxShmHandle_t myShmHandle;     // own shm handle (flagcxShmClose)
@@ -83,11 +88,13 @@ struct flagcxDevCommInternal {
   int signalCount;
   int counterCount;
   int contextCount; // = reqs.interContextCount (default 4)
-  // Host-only: MR handles + staging for cleanup
-  void *signalBufferMr;        // MR handle for signalBuffer
+  // Host-only: communicator registrations installed for these buffers.
+  // Non-null only when this DevComm created the registration and therefore
+  // must deregister it before freeing the backing allocation.
+  struct flagcxOneSideHandleInfo *ownedSignalRegistration;
   void *counterBufferMr;       // MR handle for counterBuffer
   void *putValueStagingBuffer; // 8 bytes host-pinned, MR registered
-  void *putValueStagingMr;     // MR handle for staging buffer
+  struct flagcxOneSideHandleInfo *ownedStagingRegistration;
 
   // One-sided transport readiness.  Signal send/wait must use the same
   // communicator-wide path because waits do not identify a sender.

--- a/flagcx/adaptor/include/device_api/flagcx_device_internal.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device_internal.h
@@ -92,7 +92,6 @@ struct flagcxDevCommInternal {
   // Non-null only when this DevComm created the registration and therefore
   // must deregister it before freeing the backing allocation.
   struct flagcxOneSideHandleInfo *ownedSignalRegistration;
-  void *counterBufferMr;       // MR handle for counterBuffer
   void *putValueStagingBuffer; // 8 bytes host-pinned, MR registered
   struct flagcxOneSideHandleInfo *ownedStagingRegistration;
 

--- a/test/unittest/device_api/Makefile
+++ b/test/unittest/device_api/Makefile
@@ -59,10 +59,14 @@ MPI_TARGETS := $(BINDIR)/test_device_ir_intra \
                $(BINDIR)/test_device_api_intra \
                $(BINDIR)/test_device_api_inter
 
-.PHONY: all clean run-unit run-mpi run-mpi-intra run-mpi-inter \
+.PHONY: all unit mpi clean run-unit run-mpi run-mpi-intra run-mpi-inter \
         run-mpi-unified-intra run-mpi-unified-inter run
 
-all: $(UNIT_TARGET) $(MPI_TARGETS)
+all: unit mpi
+
+unit: $(UNIT_TARGET)
+
+mpi: $(MPI_TARGETS)
 
 # Build device kernel objects via dispatcher
 KERNEL_API_TARGETS := device_api.o
@@ -126,7 +130,7 @@ $(BINDIR)/test_device_api_inter: test_device_api_inter.cpp $(DEVICE_API_OBJ) $(D
 clean:
 	@rm -rf $(BUILDDIR)
 
-run-unit: $(UNIT_TARGET)
+run-unit: unit
 	@$(UNIT_TARGET)
 
 # Env vars for inter-node testing on single node

--- a/test/unittest/device_api/Makefile
+++ b/test/unittest/device_api/Makefile
@@ -45,6 +45,13 @@ ALL_LINK := $(FLAGCX_LINK) $(MPI_LINK) $(DEVICE_LINK)
 CXXFLAGS += -DCOMPILE_KERNEL
 
 # Test targets
+UNIT_SRC := test_dev_comm_cleanup.cpp
+UNIT_OBJ := $(OBJDIR)/test_dev_comm_cleanup.o
+UNIT_TARGET := $(BINDIR)/test_dev_comm_cleanup
+UNIT_CXXFLAGS := $(filter-out -DCOMPILE_KERNEL,$(CXXFLAGS))
+UNIT_INCLUDES := $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) \
+                 -I$(PROJECT_ROOT)/flagcx/adaptor/device_api
+
 MPI_TARGETS := $(BINDIR)/test_device_ir_intra \
                $(BINDIR)/test_device_ir_inter \
                $(BINDIR)/test_device_ir_unified_intra \
@@ -55,7 +62,7 @@ MPI_TARGETS := $(BINDIR)/test_device_ir_intra \
 .PHONY: all clean run-unit run-mpi run-mpi-intra run-mpi-inter \
         run-mpi-unified-intra run-mpi-unified-inter run
 
-all: $(MPI_TARGETS)
+all: $(UNIT_TARGET) $(MPI_TARGETS)
 
 # Build device kernel objects via dispatcher
 KERNEL_API_TARGETS := device_api.o
@@ -75,6 +82,16 @@ $(TOOLS_OBJ): $(TOOLS_SRC)
 	@mkdir -p $(OBJDIR)
 	@echo "Compiling tools.cc"
 	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(ALL_INCLUDES)
+
+$(UNIT_OBJ): $(UNIT_SRC)
+	@mkdir -p $(OBJDIR)
+	@echo "Compiling $<"
+	@$(CXX) $< -o $@ -c $(UNIT_CXXFLAGS) $(UNIT_INCLUDES)
+
+$(UNIT_TARGET): $(UNIT_OBJ)
+	@mkdir -p $(BINDIR)
+	@echo "Linking   $@"
+	@$(CXX) $^ -o $@ $(FLAGCX_LINK) $(GTEST_LINK)
 
 $(BINDIR)/test_device_ir_intra: test_device_ir_intra.cpp $(DEVICE_IR_OBJ) $(DLINK_IR_OBJ) $(TOOLS_OBJ)
 	@mkdir -p $(BINDIR)
@@ -109,9 +126,8 @@ $(BINDIR)/test_device_api_inter: test_device_api_inter.cpp $(DEVICE_API_OBJ) $(D
 clean:
 	@rm -rf $(BUILDDIR)
 
-# No pure unit tests here — these all require MPI + GPU
-run-unit:
-	@echo "device_api: no unit tests (all require MPI + GPU)"
+run-unit: $(UNIT_TARGET)
+	@$(UNIT_TARGET)
 
 # Env vars for inter-node testing on single node
 HETERO_ENV := $(MPI_ENV_FLAG) FLAGCX_USE_HETERO_COMM=1 \
@@ -169,4 +185,4 @@ run-mpi-unified-inter: $(BINDIR)/test_device_ir_unified_inter
 
 run-mpi: run-mpi-intra run-mpi-inter run-mpi-unified-intra run-mpi-unified-inter
 
-run: run-mpi
+run: run-unit run-mpi

--- a/test/unittest/device_api/test_dev_comm_cleanup.cpp
+++ b/test/unittest/device_api/test_dev_comm_cleanup.cpp
@@ -1,0 +1,387 @@
+/*************************************************************************
+ * Copyright (c) 2026 BAAI. All rights reserved.
+ *
+ * Host-only tests for Device API communicator cleanup ownership.
+ ************************************************************************/
+
+#include "adaptor.h"
+#include "dev_api_backend.h"
+#include "device_api/flagcx_device.h"
+#include "flagcx_net_adaptor.h"
+#include "global_comm.h"
+#include "onesided.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace {
+
+std::vector<void *> unregisteredPtrs;
+std::vector<void *> deviceFreedPtrs;
+std::vector<void *> allocatedPtrs;
+
+enum class CleanupEventKind { Deregister, BufferFree };
+
+struct CleanupEvent {
+  CleanupEventKind kind;
+  void *ptr;
+};
+
+std::vector<CleanupEvent> cleanupEvents;
+
+flagcxResult_t recordHostUnregister(void *ptr) {
+  unregisteredPtrs.push_back(ptr);
+  return flagcxSuccess;
+}
+
+flagcxResult_t recordDeviceFree(void *ptr, flagcxMemType_t, flagcxStream_t) {
+  deviceFreedPtrs.push_back(ptr);
+  cleanupEvents.push_back({CleanupEventKind::BufferFree, ptr});
+  return flagcxSuccess;
+}
+
+flagcxResult_t recordGdrFree(void *ptr, void *) {
+  deviceFreedPtrs.push_back(ptr);
+  cleanupEvents.push_back({CleanupEventKind::BufferFree, ptr});
+  return flagcxSuccess;
+}
+
+flagcxResult_t recordMrDeregister(void *, void *mrHandle) {
+  cleanupEvents.push_back({CleanupEventKind::Deregister, mrHandle});
+  return flagcxSuccess;
+}
+
+flagcxResult_t allocateTestBuffer(void **ptr, size_t size) {
+  *ptr = malloc(size);
+  if (!*ptr)
+    return flagcxSystemError;
+  allocatedPtrs.push_back(*ptr);
+  return flagcxSuccess;
+}
+
+flagcxResult_t recordDeviceMalloc(void **ptr, size_t size, flagcxMemType_t,
+                                  flagcxStream_t) {
+  return allocateTestBuffer(ptr, size);
+}
+
+flagcxResult_t recordGdrMalloc(void **ptr, size_t size, void *) {
+  return allocateTestBuffer(ptr, size);
+}
+
+flagcxResult_t recordDeviceMemset(void *ptr, int value, size_t size,
+                                  flagcxMemType_t, flagcxStream_t) {
+  memset(ptr, value, size);
+  return flagcxSuccess;
+}
+
+flagcxResult_t failIpcMemHandleCreate(flagcxIpcMemHandle_t *, size_t *) {
+  return flagcxNotSupported;
+}
+
+flagcxOneSideHandleInfo *makeRegistration(void *buffer, void *mrHandle) {
+  flagcxOneSideHandleInfo *registration =
+      static_cast<flagcxOneSideHandleInfo *>(
+          calloc(1, sizeof(flagcxOneSideHandleInfo)));
+  if (!registration)
+    return nullptr;
+  registration->baseVas =
+      static_cast<uintptr_t *>(calloc(1, sizeof(uintptr_t)));
+  registration->rkeys = static_cast<uint32_t *>(calloc(1, sizeof(uint32_t)));
+  registration->lkeys = static_cast<uint32_t *>(calloc(1, sizeof(uint32_t)));
+  if (!registration->baseVas || !registration->rkeys || !registration->lkeys) {
+    free(registration->lkeys);
+    free(registration->rkeys);
+    free(registration->baseVas);
+    free(registration);
+    return nullptr;
+  }
+  registration->baseVas[0] = reinterpret_cast<uintptr_t>(buffer);
+  registration->localMrHandle = mrHandle;
+  registration->localRecvComm = reinterpret_cast<void *>(0x9000);
+  registration->signalIpcSlot = -1;
+  return registration;
+}
+
+void freeRegistration(flagcxOneSideHandleInfo *registration) {
+  if (!registration)
+    return;
+  free(registration->lkeys);
+  free(registration->rkeys);
+  free(registration->baseVas);
+  free(registration);
+}
+
+class DefaultDevCommCleanupTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    if (strcmp(devApiBackend->name, "default") != 0) {
+      GTEST_SKIP() << "requires the default Device API backend";
+    }
+    savedDeviceAdaptor = deviceAdaptor;
+    testDeviceAdaptor = *deviceAdaptor;
+    testDeviceAdaptor.hostUnregister = recordHostUnregister;
+    testDeviceAdaptor.deviceFree = recordDeviceFree;
+    testDeviceAdaptor.gdrMemFree = recordGdrFree;
+    deviceAdaptor = &testDeviceAdaptor;
+    unregisteredPtrs.clear();
+    deviceFreedPtrs.clear();
+    allocatedPtrs.clear();
+    cleanupEvents.clear();
+  }
+
+  void TearDown() override {
+    if (savedDeviceAdaptor)
+      deviceAdaptor = savedDeviceAdaptor;
+    for (void *ptr : allocatedPtrs)
+      free(ptr);
+    allocatedPtrs.clear();
+  }
+
+  struct flagcxDeviceAdaptor *savedDeviceAdaptor = nullptr;
+  struct flagcxDeviceAdaptor testDeviceAdaptor = {};
+};
+
+TEST_F(DefaultDevCommCleanupTest, ShmBarrierAliasesAreNotFreedTwice) {
+  flagcxDevCommInternal devComm = {};
+  devComm.nLocalRanks = 3;
+  devComm.registeredBarrierShmCount = 2;
+  devComm.peerBarrierShmPtrs =
+      static_cast<void **>(calloc(devComm.nLocalRanks, sizeof(void *)));
+  ASSERT_NE(devComm.peerBarrierShmPtrs, nullptr);
+  devComm.peerBarrierShmPtrs[0] = reinterpret_cast<void *>(0x1000);
+  devComm.peerBarrierShmPtrs[1] = reinterpret_cast<void *>(0x2000);
+  devComm.peerBarrierShmPtrs[2] = reinterpret_cast<void *>(0x3000);
+  devComm.localBarrierShmPtr = devComm.peerBarrierShmPtrs[0];
+  devComm.localBarrierFlags =
+      reinterpret_cast<uint64_t *>(devComm.localBarrierShmPtr);
+  devComm.localBarrierFlagsDeviceAllocated = false;
+  devComm.barrierDevPeerPtrsRaw = reinterpret_cast<uint64_t **>(0x4000);
+  devComm.barrierPeers = devComm.barrierDevPeerPtrsRaw;
+
+  ASSERT_EQ(devApiBackend->devCommDestroy(nullptr, &devComm), flagcxSuccess);
+
+  ASSERT_EQ(unregisteredPtrs.size(), 2u);
+  EXPECT_EQ(unregisteredPtrs[0], reinterpret_cast<void *>(0x1000));
+  EXPECT_EQ(unregisteredPtrs[1], reinterpret_cast<void *>(0x2000));
+  ASSERT_EQ(deviceFreedPtrs.size(), 1u);
+  EXPECT_EQ(deviceFreedPtrs[0], reinterpret_cast<void *>(0x4000));
+  EXPECT_EQ(devComm.localBarrierFlags, nullptr);
+  EXPECT_EQ(devComm.localBarrierShmPtr, nullptr);
+  EXPECT_EQ(devComm.registeredBarrierShmCount, 0);
+
+  ASSERT_EQ(devApiBackend->devCommDestroy(nullptr, &devComm), flagcxSuccess);
+  EXPECT_EQ(unregisteredPtrs.size(), 2u);
+  EXPECT_EQ(deviceFreedPtrs.size(), 1u);
+}
+
+TEST_F(DefaultDevCommCleanupTest, IpcBarrierAllocationIsFreedOnce) {
+  flagcxDevCommInternal devComm = {};
+  devComm.barrierIpcIndex = -1;
+  devComm.signalIpcSlot = -1;
+  devComm.localBarrierFlags = reinterpret_cast<uint64_t *>(0x5000);
+  devComm.localBarrierFlagsDeviceAllocated = true;
+
+  ASSERT_EQ(devApiBackend->devCommDestroy(nullptr, &devComm), flagcxSuccess);
+
+  EXPECT_TRUE(unregisteredPtrs.empty());
+  ASSERT_EQ(deviceFreedPtrs.size(), 1u);
+  EXPECT_EQ(deviceFreedPtrs[0], reinterpret_cast<void *>(0x5000));
+  EXPECT_EQ(devComm.localBarrierFlags, nullptr);
+  EXPECT_FALSE(devComm.localBarrierFlagsDeviceAllocated);
+}
+
+TEST_F(DefaultDevCommCleanupTest,
+       OwnedRegistrationsAreRemovedBeforeBackingBuffers) {
+  flagcxNetAdaptor netAdaptor = {};
+  netAdaptor.name = "test";
+  netAdaptor.deregMr = recordMrDeregister;
+
+  flagcxHeteroComm heteroComm = {};
+  heteroComm.rank = 0;
+  heteroComm.nRanks = 1;
+  heteroComm.netAdaptor = &netAdaptor;
+
+  flagcxComm comm = {};
+  comm.rank = 0;
+  comm.nranks = 1;
+  comm.heteroComm = &heteroComm;
+
+  void *signalBuffer = reinterpret_cast<void *>(0x6000);
+  void *stagingBuffer = reinterpret_cast<void *>(0x7000);
+  void *signalMr = reinterpret_cast<void *>(0x6100);
+  void *stagingMr = reinterpret_cast<void *>(0x7100);
+  heteroComm.signalHandle = makeRegistration(signalBuffer, signalMr);
+  heteroComm.stagingHandle = makeRegistration(stagingBuffer, stagingMr);
+  ASSERT_NE(heteroComm.signalHandle, nullptr);
+  ASSERT_NE(heteroComm.stagingHandle, nullptr);
+
+  flagcxDevCommInternal devComm = {};
+  devComm.barrierIpcIndex = -1;
+  devComm.signalIpcSlot = -1;
+  devComm.signalBuffer = static_cast<uint64_t *>(signalBuffer);
+  devComm.putValueStagingBuffer = stagingBuffer;
+  devComm.ownedSignalRegistration = heteroComm.signalHandle;
+  devComm.ownedStagingRegistration = heteroComm.stagingHandle;
+
+  ASSERT_EQ(devApiBackend->devCommDestroy(&comm, &devComm), flagcxSuccess);
+
+  EXPECT_EQ(heteroComm.signalHandle, nullptr);
+  EXPECT_EQ(heteroComm.stagingHandle, nullptr);
+  EXPECT_EQ(devComm.ownedSignalRegistration, nullptr);
+  EXPECT_EQ(devComm.ownedStagingRegistration, nullptr);
+  ASSERT_EQ(cleanupEvents.size(), 4u);
+  EXPECT_EQ(cleanupEvents[0].kind, CleanupEventKind::Deregister);
+  EXPECT_EQ(cleanupEvents[0].ptr, stagingMr);
+  EXPECT_EQ(cleanupEvents[1].kind, CleanupEventKind::Deregister);
+  EXPECT_EQ(cleanupEvents[1].ptr, signalMr);
+  EXPECT_EQ(cleanupEvents[2].kind, CleanupEventKind::BufferFree);
+  EXPECT_EQ(cleanupEvents[2].ptr, signalBuffer);
+  EXPECT_EQ(cleanupEvents[3].kind, CleanupEventKind::BufferFree);
+  EXPECT_EQ(cleanupEvents[3].ptr, stagingBuffer);
+
+  ASSERT_EQ(devApiBackend->devCommDestroy(&comm, &devComm), flagcxSuccess);
+  EXPECT_EQ(cleanupEvents.size(), 4u);
+}
+
+TEST_F(DefaultDevCommCleanupTest,
+       PreexistingRegistrationsAreNotRemovedByDestroy) {
+  flagcxNetAdaptor netAdaptor = {};
+  netAdaptor.name = "test";
+  netAdaptor.deregMr = recordMrDeregister;
+
+  flagcxHeteroComm heteroComm = {};
+  heteroComm.rank = 0;
+  heteroComm.nRanks = 1;
+  heteroComm.netAdaptor = &netAdaptor;
+
+  flagcxComm comm = {};
+  comm.rank = 0;
+  comm.nranks = 1;
+  comm.heteroComm = &heteroComm;
+
+  flagcxOneSideHandleInfo *existingSignal = makeRegistration(
+      reinterpret_cast<void *>(0x8000), reinterpret_cast<void *>(0x8100));
+  flagcxOneSideHandleInfo *existingStaging = makeRegistration(
+      reinterpret_cast<void *>(0x8200), reinterpret_cast<void *>(0x8300));
+  ASSERT_NE(existingSignal, nullptr);
+  ASSERT_NE(existingStaging, nullptr);
+  heteroComm.signalHandle = existingSignal;
+  heteroComm.stagingHandle = existingStaging;
+
+  flagcxDevCommInternal devComm = {};
+  devComm.barrierIpcIndex = -1;
+  devComm.signalIpcSlot = -1;
+  devComm.signalBuffer = reinterpret_cast<uint64_t *>(0x8400);
+  devComm.putValueStagingBuffer = reinterpret_cast<void *>(0x8500);
+
+  ASSERT_EQ(devApiBackend->devCommDestroy(&comm, &devComm), flagcxSuccess);
+
+  EXPECT_EQ(heteroComm.signalHandle, existingSignal);
+  EXPECT_EQ(heteroComm.stagingHandle, existingStaging);
+  ASSERT_EQ(cleanupEvents.size(), 2u);
+  EXPECT_EQ(cleanupEvents[0].kind, CleanupEventKind::BufferFree);
+  EXPECT_EQ(cleanupEvents[0].ptr, reinterpret_cast<void *>(0x8400));
+  EXPECT_EQ(cleanupEvents[1].kind, CleanupEventKind::BufferFree);
+  EXPECT_EQ(cleanupEvents[1].ptr, reinterpret_cast<void *>(0x8500));
+
+  heteroComm.signalHandle = nullptr;
+  heteroComm.stagingHandle = nullptr;
+  freeRegistration(existingSignal);
+  freeRegistration(existingStaging);
+}
+
+TEST_F(DefaultDevCommCleanupTest,
+       MismatchedPreexistingRegistrationsAreNotReusedOnCreate) {
+  testDeviceAdaptor.deviceMalloc = recordDeviceMalloc;
+  testDeviceAdaptor.gdrMemAlloc = recordGdrMalloc;
+  testDeviceAdaptor.deviceMemset = recordDeviceMemset;
+  testDeviceAdaptor.ipcMemHandleCreate = failIpcMemHandleCreate;
+
+  flagcxNetAdaptor netAdaptor = {};
+  netAdaptor.name = "test";
+  netAdaptor.deregMr = recordMrDeregister;
+
+  flagcxHeteroComm heteroComm = {};
+  heteroComm.rank = 0;
+  heteroComm.nRanks = 1;
+  heteroComm.nNodes = 1;
+  heteroComm.netAdaptor = &netAdaptor;
+
+  flagcxComm comm = {};
+  comm.rank = 0;
+  comm.nranks = 1;
+  comm.localRank = 0;
+  comm.localRanks = 1;
+  comm.heteroComm = &heteroComm;
+
+  flagcxOneSideHandleInfo *existingSignal = makeRegistration(
+      reinterpret_cast<void *>(0xa000), reinterpret_cast<void *>(0xa100));
+  flagcxOneSideHandleInfo *existingStaging = makeRegistration(
+      reinterpret_cast<void *>(0xa200), reinterpret_cast<void *>(0xa300));
+  ASSERT_NE(existingSignal, nullptr);
+  ASSERT_NE(existingStaging, nullptr);
+  heteroComm.signalHandle = existingSignal;
+  heteroComm.stagingHandle = existingStaging;
+
+  flagcxDevCommRequirements reqs = FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
+  reqs.interSignalCount = 1;
+  flagcxDevComm_t devComm = nullptr;
+  EXPECT_EQ(flagcxDevCommCreate(&comm, &reqs, &devComm), flagcxNotSupported);
+
+  EXPECT_EQ(devComm, nullptr);
+  EXPECT_EQ(heteroComm.signalHandle, existingSignal);
+  EXPECT_EQ(heteroComm.stagingHandle, existingStaging);
+  EXPECT_EQ(cleanupEvents.size(), allocatedPtrs.size());
+  for (const CleanupEvent &event : cleanupEvents)
+    EXPECT_EQ(event.kind, CleanupEventKind::BufferFree);
+
+  heteroComm.signalHandle = nullptr;
+  heteroComm.stagingHandle = nullptr;
+  freeRegistration(existingSignal);
+  freeRegistration(existingStaging);
+}
+
+int rollbackCallCount = 0;
+flagcxResult_t rollbackResult = flagcxSuccess;
+
+flagcxResult_t failDevCommCreate(flagcxComm_t,
+                                 const flagcxDevCommRequirements *,
+                                 flagcxDevComm_t) {
+  return flagcxSystemError;
+}
+
+flagcxResult_t recordDevCommRollback(flagcxComm_t, flagcxDevComm_t) {
+  rollbackCallCount++;
+  return rollbackResult;
+}
+
+TEST(DevCommCreateTest, PreservesCreateErrorWhenRollbackFails) {
+  struct flagcxDevApiBackend failingBackend = {};
+  failingBackend.name = "failing-test-backend";
+  failingBackend.devCommCreate = failDevCommCreate;
+  failingBackend.devCommDestroy = recordDevCommRollback;
+
+  struct flagcxDevApiBackend *savedBackend = devApiBackend;
+  devApiBackend = &failingBackend;
+  rollbackCallCount = 0;
+  rollbackResult = flagcxInternalError;
+
+  flagcxComm comm = {};
+  comm.rank = 0;
+  comm.nranks = 1;
+  comm.localRank = 0;
+  comm.localRanks = 1;
+  flagcxDevCommRequirements reqs = FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
+  flagcxDevComm_t devComm = nullptr;
+  flagcxResult_t result = flagcxDevCommCreate(&comm, &reqs, &devComm);
+
+  devApiBackend = savedBackend;
+  EXPECT_EQ(result, flagcxSystemError);
+  EXPECT_EQ(rollbackCallCount, 1);
+  EXPECT_EQ(devComm, nullptr);
+}
+
+} // namespace


### PR DESCRIPTION
### PR Category
CRL

### PR Types
Bug Fixes

### PR Description
This PR (category CRL, Bug Fixes) hardens the Device API communicator lifecycle so that a failed flagcxDevCommCreate is fully rolled back without leaking or double-freeing resources. It introduces explicit ownership tracking for one-sided MR registrations and SHM/barrier allocations, makes devCommDestroy safe to call on a zero- or partially-initialized devComm, and adds host-only unit tests plus CI wiring to exercise the cleanup paths.