### PR TITLE
fix(torch): complete FlagOS Enflame collective flow

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -209,6 +209,10 @@ This document provides a comprehensive reference for all environment variables u
 | `FLAGCX_DEVICE_ADAPTOR_PLUGIN` | None | Path to device adaptor plugin shared library |
 | `FLAGCX_NET_ADAPTOR_PLUGIN` | None | Path to network adaptor plugin shared library |
 | `FLAGCX_CCL_ADAPTOR_PLUGIN` | None | Path to CCL adaptor plugin shared library |
+| `FLAGCX_TORCH_BACKEND` | `torch_gcu` | Torch integration used by the Enflame plugin. Set to `flagos` to build and load against torch-fl without importing or linking `torch_gcu` |
+| `FLAGOS_INSTALL_PATH` | None | torch-fl package root containing `include/flagos.h` and `lib/libflagos.so` for `FLAGCX_TORCH_BACKEND=flagos` builds |
+| `FLAGOS_INCLUDE_DIR` | None | Explicit directory containing `flagos.h`; overrides the include path derived from `FLAGOS_INSTALL_PATH` |
+| `FLAGOS_LIBRARY_DIR` | None | Explicit directory containing `libflagos.so`; overrides the library path derived from `FLAGOS_INSTALL_PATH` |
 
 ---
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -209,10 +209,50 @@ This document provides a comprehensive reference for all environment variables u
 | `FLAGCX_DEVICE_ADAPTOR_PLUGIN` | None | Path to device adaptor plugin shared library |
 | `FLAGCX_NET_ADAPTOR_PLUGIN` | None | Path to network adaptor plugin shared library |
 | `FLAGCX_CCL_ADAPTOR_PLUGIN` | None | Path to CCL adaptor plugin shared library |
-| `FLAGCX_TORCH_BACKEND` | `torch_gcu` | Torch integration used by the Enflame plugin. Set to `flagos` to build and load against torch-fl without importing or linking `torch_gcu` |
+| `FLAGCX_TORCH_BACKEND` | `vendor` | Torch plugin backend. `vendor` uses the adaptor's native Torch package; `flagos` uses torch-fl and currently supports only Ascend and Enflame |
 | `FLAGOS_INSTALL_PATH` | None | torch-fl package root containing `include/flagos.h` and `lib/libflagos.so` for `FLAGCX_TORCH_BACKEND=flagos` builds |
 | `FLAGOS_INCLUDE_DIR` | None | Explicit directory containing `flagos.h`; overrides the include path derived from `FLAGOS_INSTALL_PATH` |
 | `FLAGOS_LIBRARY_DIR` | None | Explicit directory containing `libflagos.so`; overrides the library path derived from `FLAGOS_INSTALL_PATH` |
+
+### Torch Plugin Backends
+
+The Torch plugin supports the following backend matrix:
+
+| Adaptor | `vendor` | `flagos` |
+|---------|----------|----------|
+| `ascend` | `torch_npu`, device type `npu` | `torch_fl`, device type `flagos` |
+| `enflame` | `torch_gcu`, device type `gcu` | `torch_fl`, device type `flagos` |
+
+The default `vendor` mode preserves the existing Torch integration. Select the
+same backend when building and running the plugin. For example:
+
+```bash
+# Existing vendor integration
+FLAGCX_ADAPTOR=ascend FLAGCX_TORCH_BACKEND=vendor \
+  pip install . --no-build-isolation
+
+# FlagOS integration
+FLAGCX_ADAPTOR=ascend FLAGCX_TORCH_BACKEND=flagos \
+  pip install . --no-build-isolation
+FLAGCX_TORCH_BACKEND=flagos python your_application.py
+```
+
+For a FlagOS build, install `torch_fl` or set `FLAGOS_INSTALL_PATH`. The
+`FLAGOS_INCLUDE_DIR` and `FLAGOS_LIBRARY_DIR` variables can override its
+individual include and library directories. Selecting `flagos` for another
+adaptor fails during configuration instead of falling back to a vendor package.
+
+After building, run the same two-rank smoke test in either mode:
+
+```bash
+FLAGCX_TORCH_BACKEND=vendor torchrun --nproc_per_node=2 \
+  plugin/torch/tests/distributed_smoke.py --adaptor ascend
+
+FLAGCX_TORCH_BACKEND=flagos torchrun --nproc_per_node=2 \
+  plugin/torch/tests/distributed_smoke.py --adaptor ascend
+```
+
+Replace `ascend` with `enflame` to test GCU hardware.
 
 ---
 

--- a/plugin/torch/_build_config.py
+++ b/plugin/torch/_build_config.py
@@ -9,6 +9,7 @@ class selection logic.
 import os
 import shutil
 import sys
+from dataclasses import dataclass
 
 from packaging.version import Version, parse as vparse
 
@@ -50,6 +51,56 @@ ADAPTOR_TO_MAKE_FLAG = {
 }
 
 VALID_ADAPTORS = list(ADAPTOR_MAP.keys())
+ADAPTOR_BY_FLAG = {flag: name for name, flag in ADAPTOR_MAP.items()}
+
+TORCH_BACKEND_VENDOR = "vendor"
+TORCH_BACKEND_FLAGOS = "flagos"
+VALID_TORCH_BACKENDS = (TORCH_BACKEND_VENDOR, TORCH_BACKEND_FLAGOS)
+FLAGOS_ADAPTORS = ("ascend", "enflame")
+
+
+@dataclass(frozen=True)
+class TorchBackendConfig:
+    name: str
+    python_package: str
+    device_name: str
+    compile_flags: tuple
+
+
+def resolve_torch_backend(adaptor):
+    """Resolve and validate the Torch integration for an adaptor."""
+    backend = os.environ.get("FLAGCX_TORCH_BACKEND", TORCH_BACKEND_VENDOR)
+    backend = backend.strip().lower() or TORCH_BACKEND_VENDOR
+    if backend not in VALID_TORCH_BACKENDS:
+        raise RuntimeError(
+            f"Invalid FLAGCX_TORCH_BACKEND={backend!r}. "
+            f"Valid values: {', '.join(VALID_TORCH_BACKENDS)}"
+        )
+    if backend == TORCH_BACKEND_FLAGOS and adaptor not in FLAGOS_ADAPTORS:
+        raise RuntimeError(
+            "FLAGCX_TORCH_BACKEND=flagos currently supports only the "
+            f"ascend and enflame adaptors, not {adaptor!r}"
+        )
+
+    if backend == TORCH_BACKEND_FLAGOS:
+        return TorchBackendConfig(
+            name=backend,
+            python_package="torch_fl",
+            device_name="flagos",
+            compile_flags=("-DFLAGCX_TORCH_BACKEND_FLAGOS",),
+        )
+
+    vendor_packages = {
+        "ascend": ("torch_npu", "npu"),
+        "enflame": ("torch_gcu", "gcu"),
+    }
+    python_package, device_name = vendor_packages.get(adaptor, ("", ""))
+    return TorchBackendConfig(
+        name=backend,
+        python_package=python_package,
+        device_name=device_name,
+        compile_flags=(),
+    )
 
 # Platform detection: command -> adaptor name
 # Order matters: nvidia-smi and rocm-smi last (some platforms are CUDA/ROCm compatible)
@@ -137,12 +188,64 @@ def detect_torch_flag():
     return torch_flag
 
 
-def get_device_config(adaptor_flag):
+def _get_flagos_config():
+    """Return include and library paths for the torch-fl runtime."""
+    install_path = os.environ.get("FLAGOS_INSTALL_PATH", "").strip()
+    include_dir = os.environ.get("FLAGOS_INCLUDE_DIR", "").strip()
+    library_dir = os.environ.get("FLAGOS_LIBRARY_DIR", "").strip()
+
+    if install_path:
+        include_dir = include_dir or os.path.join(install_path, "include")
+        library_dir = library_dir or os.path.join(install_path, "lib")
+
+    if not include_dir or not library_dir:
+        try:
+            import torch_fl
+        except ImportError as error:
+            raise RuntimeError(
+                "FLAGCX_TORCH_BACKEND=flagos requires torch-fl or explicit "
+                "FLAGOS_INCLUDE_DIR and FLAGOS_LIBRARY_DIR"
+            ) from error
+
+        torch_fl_path = os.path.dirname(os.path.abspath(torch_fl.__file__))
+        if not include_dir:
+            include_candidates = [
+                os.path.join(torch_fl_path, "include"),
+                os.path.join(os.path.dirname(torch_fl_path), "csrc", "include"),
+            ]
+            include_dir = next(
+                (
+                    path
+                    for path in include_candidates
+                    if os.path.isfile(os.path.join(path, "flagos.h"))
+                ),
+                include_candidates[0],
+            )
+        library_dir = library_dir or os.path.join(torch_fl_path, "lib")
+
+    header_path = os.path.join(include_dir, "flagos.h")
+    library_path = os.path.join(library_dir, "libflagos.so")
+    if not os.path.isfile(header_path):
+        raise RuntimeError(
+            f"FLAGCX_TORCH_BACKEND=flagos requires flagos.h; not found at {header_path}. "
+            "Set FLAGOS_INSTALL_PATH or FLAGOS_INCLUDE_DIR."
+        )
+    if not os.path.isfile(library_path):
+        raise RuntimeError(
+            "FLAGCX_TORCH_BACKEND=flagos requires libflagos.so; not found at "
+            f"{library_path}. Set FLAGOS_INSTALL_PATH or FLAGOS_LIBRARY_DIR."
+        )
+    return [include_dir], [library_dir], ["flagos"]
+
+
+def get_device_config(adaptor_flag, torch_backend=None):
     """Return (extra_include_dirs, extra_library_dirs, extra_libs) for the
     given adaptor define flag."""
     include_dirs = []
     library_dirs = []
     libs = []
+    adaptor = ADAPTOR_BY_FLAG[adaptor_flag]
+    torch_backend = torch_backend or resolve_torch_backend(adaptor)
 
     if adaptor_flag == "-DUSE_NVIDIA_ADAPTOR":
         include_dirs += ["/usr/local/cuda/include"]
@@ -202,24 +305,46 @@ def get_device_config(adaptor_flag):
         library_dirs += ["/opt/kunlun/lib"]
         libs += ["cuda", "cudart", "c10_cuda", "torch_cuda"]
     elif adaptor_flag == "-DUSE_ASCEND_ADAPTOR":
-        import torch_npu
-        pytorch_npu_install_path = os.path.dirname(os.path.abspath(torch_npu.__file__))
-        pytorch_library_path = os.path.join(pytorch_npu_install_path, "lib")
-        # CANN toolkit headers must come BEFORE torch_npu bundled third_party
-        # ACL headers (torch_npu 2.11.0 bundles newer ACL headers incompatible
-        # with CANN 8.5.1).  We also symlink torch_npu's third_party/acl/inc/acl
-        # to CANN's acl/ directory (see install.sh), but adding the CANN include
-        # path here is a belt-and-suspenders fix for hccl.h etc.
-        cann_home = os.environ.get("ASCEND_HOME_PATH", "")
-        if cann_home:
-            import platform as _pf
-            _arch = "aarch64-linux" if _pf.machine().startswith("aarch") else "x86_64-linux"
-            _cann_inc = os.path.join(cann_home, _arch, "include")
-            if os.path.isdir(_cann_inc):
-                include_dirs += [_cann_inc]
-        include_dirs += [os.path.join(pytorch_npu_install_path, "include")]
-        library_dirs += [pytorch_library_path]
-        libs += ["torch_npu"]
+        if torch_backend.name == TORCH_BACKEND_FLAGOS:
+            cann_home = (
+                os.environ.get("ASCEND_HOME_PATH")
+                or os.environ.get("DEVICE_HOME")
+                or "/usr/local/Ascend/ascend-toolkit/latest"
+            )
+            include_dirs += [os.path.join(cann_home, "include")]
+            library_dirs += [os.path.join(cann_home, "lib64")]
+            libs += ["ascendcl"]
+            flagos_includes, flagos_libdirs, flagos_libs = _get_flagos_config()
+            include_dirs += flagos_includes
+            library_dirs += flagos_libdirs
+            libs += flagos_libs
+        else:
+            import torch_npu
+
+            pytorch_npu_install_path = os.path.dirname(
+                os.path.abspath(torch_npu.__file__)
+            )
+            pytorch_library_path = os.path.join(pytorch_npu_install_path, "lib")
+            # CANN toolkit headers must come BEFORE torch_npu bundled third_party
+            # ACL headers (torch_npu 2.11.0 bundles newer ACL headers incompatible
+            # with CANN 8.5.1). We also symlink torch_npu's third_party/acl/inc/acl
+            # to CANN's acl/ directory (see install.sh), but adding the CANN include
+            # path here is a belt-and-suspenders fix for hccl.h etc.
+            cann_home = os.environ.get("ASCEND_HOME_PATH", "")
+            if cann_home:
+                import platform as _pf
+
+                arch = (
+                    "aarch64-linux"
+                    if _pf.machine().startswith("aarch")
+                    else "x86_64-linux"
+                )
+                cann_include = os.path.join(cann_home, arch, "include")
+                if os.path.isdir(cann_include):
+                    include_dirs += [cann_include]
+            include_dirs += [os.path.join(pytorch_npu_install_path, "include")]
+            library_dirs += [pytorch_library_path]
+            libs += ["torch_npu"]
     elif adaptor_flag == "-DUSE_AMD_ADAPTOR":
         include_dirs += ["/opt/rocm/include"]
         library_dirs += ["/opt/rocm/lib"]
@@ -235,47 +360,14 @@ def get_device_config(adaptor_flag):
         include_dirs += ["/opt/tops/include"]
         library_dirs += ["/opt/tops/lib"]
         libs += ["topsrt"]
-        if os.environ.get("FLAGCX_TORCH_BACKEND", "torch_gcu").strip().lower() == "flagos":
-            # torch_fl owns the PrivateUse1 stream/event implementation. Keep
-            # this mode independent of the vendor torch_gcu package.
-            flagos_install_path = os.environ.get("FLAGOS_INSTALL_PATH", "")
-            flagos_include_dir = os.environ.get("FLAGOS_INCLUDE_DIR", "")
-            flagos_library_dir = os.environ.get("FLAGOS_LIBRARY_DIR", "")
-            if flagos_install_path:
-                flagos_include_dir = flagos_include_dir or os.path.join(
-                    flagos_install_path, "include"
-                )
-                flagos_library_dir = flagos_library_dir or os.path.join(
-                    flagos_install_path, "lib"
-                )
-            if not flagos_include_dir or not flagos_library_dir:
-                import torch_fl
-
-                torch_fl_path = os.path.dirname(os.path.abspath(torch_fl.__file__))
-                flagos_include_dir = flagos_include_dir or os.path.join(
-                    torch_fl_path, "include"
-                )
-                flagos_library_dir = flagos_library_dir or os.path.join(
-                    torch_fl_path, "lib"
-                )
-                if not os.path.isfile(os.path.join(flagos_include_dir, "flagos.h")):
-                    source_root = os.path.dirname(torch_fl_path)
-                    flagos_include_dir = os.path.join(source_root, "csrc", "include")
-            if not os.path.isfile(os.path.join(flagos_include_dir, "flagos.h")):
-                raise RuntimeError(
-                    "FLAGCX_TORCH_BACKEND=flagos requires flagos.h; set "
-                    "FLAGOS_INSTALL_PATH or FLAGOS_INCLUDE_DIR"
-                )
-            if not os.path.isfile(os.path.join(flagos_library_dir, "libflagos.so")):
-                raise RuntimeError(
-                    "FLAGCX_TORCH_BACKEND=flagos requires libflagos.so; set "
-                    "FLAGOS_INSTALL_PATH or FLAGOS_LIBRARY_DIR"
-                )
-            include_dirs += [flagos_include_dir]
-            library_dirs += [flagos_library_dir]
-            libs += ["flagos"]
+        if torch_backend.name == TORCH_BACKEND_FLAGOS:
+            flagos_includes, flagos_libdirs, flagos_libs = _get_flagos_config()
+            include_dirs += flagos_includes
+            library_dirs += flagos_libdirs
+            libs += flagos_libs
         else:
             import torch_gcu
+
             pytorch_gcu_install_path = os.path.dirname(os.path.abspath(torch_gcu.__file__))
             pytorch_library_path = os.path.join(pytorch_gcu_install_path, "lib")
             include_dirs += [os.path.join(pytorch_gcu_install_path, "include")]
@@ -305,26 +397,8 @@ def get_device_config(adaptor_flag):
     return include_dirs, library_dirs, libs
 
 
-def get_device_rpath_dirs(adaptor_flag, library_dirs):
+def get_device_rpath_dirs(adaptor_flag, library_dirs, torch_backend=None):
     """Return runtime library paths that belong in the extension artifact."""
-    if (
-        adaptor_flag == "-DUSE_ENFLAME_ADAPTOR"
-        and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos"
-    ):
-        flagos_library_dir = os.environ.get("FLAGOS_LIBRARY_DIR", "")
-        flagos_install_path = os.environ.get("FLAGOS_INSTALL_PATH", "")
-        if not flagos_library_dir and flagos_install_path:
-            flagos_library_dir = os.path.join(flagos_install_path, "lib")
-        if not flagos_library_dir:
-            try:
-                import torch_fl
-
-                flagos_library_dir = os.path.join(
-                    os.path.dirname(os.path.abspath(torch_fl.__file__)), "lib"
-                )
-            except ImportError:
-                pass
-        return [path for path in library_dirs if path != flagos_library_dir]
     return list(library_dirs)
 
 

--- a/plugin/torch/_build_config.py
+++ b/plugin/torch/_build_config.py
@@ -232,12 +232,55 @@ def get_device_config(adaptor_flag):
         library_dirs += ["/usr/local/kuiper/lib", txda_library_path]
         libs += ["torch_txda", "hpgr"]
     elif adaptor_flag == "-DUSE_ENFLAME_ADAPTOR":
-        import torch_gcu
-        pytorch_gcu_install_path = os.path.dirname(os.path.abspath(torch_gcu.__file__))
-        pytorch_library_path = os.path.join(pytorch_gcu_install_path, "lib")
-        include_dirs += ["/opt/tops/include", os.path.join(pytorch_gcu_install_path, "include")]
-        library_dirs += ["/opt/tops/lib", pytorch_library_path]
-        libs += ["topsrt", "torch_gcu"]
+        include_dirs += ["/opt/tops/include"]
+        library_dirs += ["/opt/tops/lib"]
+        libs += ["topsrt"]
+        if os.environ.get("FLAGCX_TORCH_BACKEND", "torch_gcu").strip().lower() == "flagos":
+            # torch_fl owns the PrivateUse1 stream/event implementation. Keep
+            # this mode independent of the vendor torch_gcu package.
+            flagos_install_path = os.environ.get("FLAGOS_INSTALL_PATH", "")
+            flagos_include_dir = os.environ.get("FLAGOS_INCLUDE_DIR", "")
+            flagos_library_dir = os.environ.get("FLAGOS_LIBRARY_DIR", "")
+            if flagos_install_path:
+                flagos_include_dir = flagos_include_dir or os.path.join(
+                    flagos_install_path, "include"
+                )
+                flagos_library_dir = flagos_library_dir or os.path.join(
+                    flagos_install_path, "lib"
+                )
+            if not flagos_include_dir or not flagos_library_dir:
+                import torch_fl
+
+                torch_fl_path = os.path.dirname(os.path.abspath(torch_fl.__file__))
+                flagos_include_dir = flagos_include_dir or os.path.join(
+                    torch_fl_path, "include"
+                )
+                flagos_library_dir = flagos_library_dir or os.path.join(
+                    torch_fl_path, "lib"
+                )
+                if not os.path.isfile(os.path.join(flagos_include_dir, "flagos.h")):
+                    source_root = os.path.dirname(torch_fl_path)
+                    flagos_include_dir = os.path.join(source_root, "csrc", "include")
+            if not os.path.isfile(os.path.join(flagos_include_dir, "flagos.h")):
+                raise RuntimeError(
+                    "FLAGCX_TORCH_BACKEND=flagos requires flagos.h; set "
+                    "FLAGOS_INSTALL_PATH or FLAGOS_INCLUDE_DIR"
+                )
+            if not os.path.isfile(os.path.join(flagos_library_dir, "libflagos.so")):
+                raise RuntimeError(
+                    "FLAGCX_TORCH_BACKEND=flagos requires libflagos.so; set "
+                    "FLAGOS_INSTALL_PATH or FLAGOS_LIBRARY_DIR"
+                )
+            include_dirs += [flagos_include_dir]
+            library_dirs += [flagos_library_dir]
+            libs += ["flagos"]
+        else:
+            import torch_gcu
+            pytorch_gcu_install_path = os.path.dirname(os.path.abspath(torch_gcu.__file__))
+            pytorch_library_path = os.path.join(pytorch_gcu_install_path, "lib")
+            include_dirs += [os.path.join(pytorch_gcu_install_path, "include")]
+            library_dirs += [pytorch_library_path]
+            libs += ["torch_gcu"]
     elif adaptor_flag == "-DUSE_SUNRISE_ADAPTOR":
         import torch_ptpu
         torch_ptpu_dir = os.path.dirname(os.path.abspath(torch_ptpu.__file__))
@@ -260,6 +303,29 @@ def get_device_config(adaptor_flag):
         libs += ["cuda", "cudart", "c10_cuda", "torch_cuda"]
 
     return include_dirs, library_dirs, libs
+
+
+def get_device_rpath_dirs(adaptor_flag, library_dirs):
+    """Return runtime library paths that belong in the extension artifact."""
+    if (
+        adaptor_flag == "-DUSE_ENFLAME_ADAPTOR"
+        and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos"
+    ):
+        flagos_library_dir = os.environ.get("FLAGOS_LIBRARY_DIR", "")
+        flagos_install_path = os.environ.get("FLAGOS_INSTALL_PATH", "")
+        if not flagos_library_dir and flagos_install_path:
+            flagos_library_dir = os.path.join(flagos_install_path, "lib")
+        if not flagos_library_dir:
+            try:
+                import torch_fl
+
+                flagos_library_dir = os.path.join(
+                    os.path.dirname(os.path.abspath(torch_fl.__file__)), "lib"
+                )
+            except ImportError:
+                pass
+        return [path for path in library_dirs if path != flagos_library_dir]
+    return list(library_dirs)
 
 
 def get_ext_classes(adaptor_flag):

--- a/plugin/torch/flagcx/__init__.py
+++ b/plugin/torch/flagcx/__init__.py
@@ -6,23 +6,15 @@ os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
 import torch
 os.environ.pop('TORCH_DEVICE_BACKEND_AUTOLOAD')
 
+from ._backend_loader import load_torch_device_backend
+
 # Pre-import the device backend (if any) before loading _C.so.
 # Loading _C.so dynamically links against the device library (e.g.
 # libtorch_npu.so), which can register the accelerator at the C++ level.
 # If we don't import the Python package first, PyTorch's auto-loader
 # will later try to register the same accelerator again, causing a
 # "Two accelerators cannot be used at the same time" error.
-_DEVICE_BACKENDS = ["torch_npu", "torch_mlu", "torch_musa", "torch_txda", "torch_gcu", "torch_ptpu"]
-if os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
-    import torch_fl  # noqa: F401 - loads libflagos.so before the extension
-
-    _DEVICE_BACKENDS.remove("torch_gcu")
-for _pkg in _DEVICE_BACKENDS:
-    try:
-        __import__(_pkg)
-        break
-    except Exception:
-        continue
+load_torch_device_backend()
 
 from functools import wraps
 import torch.distributed as dist

--- a/plugin/torch/flagcx/__init__.py
+++ b/plugin/torch/flagcx/__init__.py
@@ -13,6 +13,10 @@ os.environ.pop('TORCH_DEVICE_BACKEND_AUTOLOAD')
 # will later try to register the same accelerator again, causing a
 # "Two accelerators cannot be used at the same time" error.
 _DEVICE_BACKENDS = ["torch_npu", "torch_mlu", "torch_musa", "torch_txda", "torch_gcu", "torch_ptpu"]
+if os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
+    import torch_fl  # noqa: F401 - loads libflagos.so before the extension
+
+    _DEVICE_BACKENDS.remove("torch_gcu")
 for _pkg in _DEVICE_BACKENDS:
     try:
         __import__(_pkg)
@@ -35,7 +39,9 @@ def init():
     pass
 
 def replace_prefix(arg):
-    device_list = ["cuda", "mlu", "npu", "musa", "txda", "gcu", "ptpu"]
+    device_list = [
+        "cuda", "mlu", "npu", "musa", "txda", "gcu", "flagos", "ptpu"
+    ]
     flagcx_prefix = "flagcx_dev"
     if isinstance(arg, str):
         for string in device_list:

--- a/plugin/torch/flagcx/_backend_loader.py
+++ b/plugin/torch/flagcx/_backend_loader.py
@@ -1,0 +1,39 @@
+import importlib
+import os
+
+
+VENDOR_BACKEND_PACKAGES = (
+    "torch_npu",
+    "torch_mlu",
+    "torch_musa",
+    "torch_txda",
+    "torch_gcu",
+    "torch_ptpu",
+)
+VALID_TORCH_BACKENDS = ("vendor", "flagos")
+
+
+def selected_torch_backend():
+    backend = os.environ.get("FLAGCX_TORCH_BACKEND", "vendor")
+    backend = backend.strip().lower() or "vendor"
+    if backend not in VALID_TORCH_BACKENDS:
+        raise RuntimeError(
+            f"Invalid FLAGCX_TORCH_BACKEND={backend!r}. "
+            f"Valid values: {', '.join(VALID_TORCH_BACKENDS)}"
+        )
+    return backend
+
+
+def load_torch_device_backend():
+    """Load exactly one PrivateUse1 provider before loading flagcx._C."""
+    if selected_torch_backend() == "flagos":
+        importlib.import_module("torch_fl")
+        return "torch_fl"
+
+    for package in VENDOR_BACKEND_PACKAGES:
+        try:
+            importlib.import_module(package)
+            return package
+        except Exception:
+            continue
+    return None

--- a/plugin/torch/flagcx/include/backend_flagcx.hpp
+++ b/plugin/torch/flagcx/include/backend_flagcx.hpp
@@ -78,6 +78,7 @@ private:
   flagcxStream_t stream_;
   flagcxDeviceHandle_t devHandle_;
   c10::intrusive_ptr<c10::ivalue::Future> future_;
+  std::vector<at::Tensor> stashedTensors_;
   int deviceId_;
   bool isBarrierOp_;
   std::unique_ptr<flagcxEvent> event_;
@@ -247,7 +248,11 @@ public:
 #elif USE_TSM_ADAPTOR
     devName = "txda";
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+    devName = "flagos";
+#else
     devName = "gcu";
+#endif
 #elif USE_SUNRISE_ADAPTOR
     devName = "ptpu";
 #endif

--- a/plugin/torch/flagcx/include/backend_flagcx.hpp
+++ b/plugin/torch/flagcx/include/backend_flagcx.hpp
@@ -232,7 +232,11 @@ public:
 #ifdef USE_NVIDIA_ADAPTOR
     devName = "cuda";
 #elif USE_ASCEND_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+    devName = "flagos";
+#else
     devName = "npu";
+#endif
 #elif USE_ILUVATAR_COREX_ADAPTOR
     devName = "cuda";
 #elif USE_CAMBRICON_ADAPTOR
@@ -298,7 +302,7 @@ protected:
   // flagcxTuner knows which communicator it is tuning
   bool recordingEnded = false;
 #endif
-#ifdef USE_ASCEND_ADAPTOR
+#if defined(USE_ASCEND_ADAPTOR) && !defined(FLAGCX_TORCH_BACKEND_FLAGOS)
   aclrtStream acl_stream;
 #endif
 

--- a/plugin/torch/flagcx/include/event_flagcx.hpp
+++ b/plugin/torch/flagcx/include/event_flagcx.hpp
@@ -41,9 +41,14 @@
 #include "torch_txda/csrc/core/TXDAStream.h"
 #include <tx_runtime.h>
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+#include <flagos.h>
+#include <tops/tops_runtime_api.h>
+#else
 #include <gcu/gcu_event.h>
 #include <gcu/gcu_guard.h>
 #include <tops/tops_runtime_api.h>
+#endif
 #elif USE_SUNRISE_ADAPTOR
 #include <tang_runtime.h>
 #include <torch_ptpu/core/Event.h>
@@ -355,6 +360,51 @@ private:
 #elif USE_ENFLAME_ADAPTOR
 class flagcxTopsEvent : public flagcxEvent {
 public:
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  flagcxTopsEvent() {
+    TORCH_CHECK(
+        topsEventCreateWithFlags(&event_, topsEventDisableTiming) == topsSuccess,
+        "topsEventCreateWithFlags failed");
+  }
+
+  ~flagcxTopsEvent() override {
+    if (event_ != nullptr) {
+      topsEventDestroy(event_);
+    }
+  }
+
+  void record(const int deviceId) override {
+    TORCH_CHECK(
+        topsEventRecord(event_, reinterpret_cast<topsStream_t>(
+            GetCurrentStreamForDevice(deviceId))) == topsSuccess,
+        "topsEventRecord failed");
+  }
+
+  void record(const flagcxStream_t &stream, const int /*deviceId*/) override {
+    TORCH_CHECK(
+        topsEventRecord(event_, *reinterpret_cast<topsStream_t *>(stream)) ==
+            topsSuccess,
+        "topsEventRecord failed");
+  }
+
+  void block(const int deviceId) override {
+    TORCH_CHECK(
+        topsStreamWaitEvent(
+            reinterpret_cast<topsStream_t>(GetCurrentStreamForDevice(deviceId)),
+            event_, 0) == topsSuccess,
+        "topsStreamWaitEvent failed");
+  }
+
+  void block(const flagcxStream_t &stream, const int /*deviceId*/) override {
+    TORCH_CHECK(
+        topsStreamWaitEvent(*reinterpret_cast<topsStream_t *>(stream), event_, 0) ==
+            topsSuccess,
+        "topsStreamWaitEvent failed");
+  }
+
+private:
+  topsEvent_t event_ = nullptr;
+#else
   flagcxTopsEvent() { topsEvent_ = torch_gcu::GCUEvent(); }
 
   void record(const int deviceId) override {
@@ -377,6 +427,7 @@ public:
 
 private:
   torch_gcu::GCUEvent topsEvent_;
+#endif
 };
 #elif USE_SUNRISE_ADAPTOR
 class flagcxPtpuEvent : public flagcxEvent {

--- a/plugin/torch/flagcx/include/event_flagcx.hpp
+++ b/plugin/torch/flagcx/include/event_flagcx.hpp
@@ -362,9 +362,9 @@ class flagcxTopsEvent : public flagcxEvent {
 public:
 #ifdef FLAGCX_TORCH_BACKEND_FLAGOS
   flagcxTopsEvent() {
-    TORCH_CHECK(
-        topsEventCreateWithFlags(&event_, topsEventDisableTiming) == topsSuccess,
-        "topsEventCreateWithFlags failed");
+    TORCH_CHECK(topsEventCreateWithFlags(&event_, topsEventDisableTiming) ==
+                    topsSuccess,
+                "topsEventCreateWithFlags failed");
   }
 
   ~flagcxTopsEvent() override {
@@ -374,32 +374,29 @@ public:
   }
 
   void record(const int deviceId) override {
-    TORCH_CHECK(
-        topsEventRecord(event_, reinterpret_cast<topsStream_t>(
-            GetCurrentStreamForDevice(deviceId))) == topsSuccess,
-        "topsEventRecord failed");
+    TORCH_CHECK(topsEventRecord(event_, reinterpret_cast<topsStream_t>(
+                                            GetCurrentStreamForDevice(
+                                                deviceId))) == topsSuccess,
+                "topsEventRecord failed");
   }
 
   void record(const flagcxStream_t &stream, const int /*deviceId*/) override {
-    TORCH_CHECK(
-        topsEventRecord(event_, *reinterpret_cast<topsStream_t *>(stream)) ==
-            topsSuccess,
-        "topsEventRecord failed");
+    TORCH_CHECK(topsEventRecord(event_, *reinterpret_cast<topsStream_t *>(
+                                            stream)) == topsSuccess,
+                "topsEventRecord failed");
   }
 
   void block(const int deviceId) override {
-    TORCH_CHECK(
-        topsStreamWaitEvent(
-            reinterpret_cast<topsStream_t>(GetCurrentStreamForDevice(deviceId)),
-            event_, 0) == topsSuccess,
-        "topsStreamWaitEvent failed");
+    TORCH_CHECK(topsStreamWaitEvent(reinterpret_cast<topsStream_t>(
+                                        GetCurrentStreamForDevice(deviceId)),
+                                    event_, 0) == topsSuccess,
+                "topsStreamWaitEvent failed");
   }
 
   void block(const flagcxStream_t &stream, const int /*deviceId*/) override {
-    TORCH_CHECK(
-        topsStreamWaitEvent(*reinterpret_cast<topsStream_t *>(stream), event_, 0) ==
-            topsSuccess,
-        "topsStreamWaitEvent failed");
+    TORCH_CHECK(topsStreamWaitEvent(*reinterpret_cast<topsStream_t *>(stream),
+                                    event_, 0) == topsSuccess,
+                "topsStreamWaitEvent failed");
   }
 
 private:

--- a/plugin/torch/flagcx/include/event_flagcx.hpp
+++ b/plugin/torch/flagcx/include/event_flagcx.hpp
@@ -7,7 +7,16 @@
 
 #include "flagcx.h"
 
-#ifdef USE_NVIDIA_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+#if defined(USE_ASCEND_ADAPTOR)
+#include <acl/acl.h>
+#elif defined(USE_ENFLAME_ADAPTOR)
+#include <tops/tops_runtime_api.h>
+#else
+#error "The FlagOS torch backend supports only Ascend and Enflame"
+#endif
+#include <flagos.h>
+#elif USE_NVIDIA_ADAPTOR
 #include <ATen/cuda/CUDAEvent.h>
 #include <cuda_runtime.h>
 #elif USE_ASCEND_ADAPTOR
@@ -148,6 +157,48 @@ private:
 #elif USE_ASCEND_ADAPTOR
 class flagcxCannEvent : public flagcxEvent {
 public:
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  flagcxCannEvent() {
+    TORCH_CHECK(aclrtCreateEventWithFlag(&event_, ACL_EVENT_TIME_LINE) ==
+                    ACL_SUCCESS,
+                "aclrtCreateEventWithFlag failed");
+  }
+
+  ~flagcxCannEvent() override {
+    if (event_ != nullptr) {
+      aclrtDestroyEvent(event_);
+    }
+  }
+
+  void record(const int deviceId) override {
+    auto stream =
+        reinterpret_cast<aclrtStream>(GetCurrentStreamForDevice(deviceId));
+    TORCH_CHECK(aclrtRecordEvent(event_, stream) == ACL_SUCCESS,
+                "aclrtRecordEvent failed");
+  }
+
+  void record(const flagcxStream_t &stream, const int /*deviceId*/) override {
+    TORCH_CHECK(aclrtRecordEvent(event_, *reinterpret_cast<aclrtStream *>(
+                                             stream)) == ACL_SUCCESS,
+                "aclrtRecordEvent failed");
+  }
+
+  void block(const int deviceId) override {
+    auto stream =
+        reinterpret_cast<aclrtStream>(GetCurrentStreamForDevice(deviceId));
+    TORCH_CHECK(aclrtStreamWaitEvent(stream, event_) == ACL_SUCCESS,
+                "aclrtStreamWaitEvent failed");
+  }
+
+  void block(const flagcxStream_t &stream, const int /*deviceId*/) override {
+    TORCH_CHECK(aclrtStreamWaitEvent(*reinterpret_cast<aclrtStream *>(stream),
+                                     event_) == ACL_SUCCESS,
+                "aclrtStreamWaitEvent failed");
+  }
+
+private:
+  aclrtEvent event_ = nullptr;
+#else
   flagcxCannEvent() { npu_event = c10_npu::NPUEvent(); }
 
   void record(const int device_id) override {
@@ -168,6 +219,7 @@ public:
 
 private:
   c10_npu::NPUEvent npu_event;
+#endif
 };
 #elif USE_CAMBRICON_ADAPTOR
 class flagcxMluEvent : public flagcxEvent {

--- a/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
+++ b/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
@@ -54,10 +54,15 @@
 #include <c10/core/impl/InlineStreamGuard.h>
 #include <tx_runtime.h>
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+#include <flagos.h>
+#include <tops/tops_runtime_api.h>
+#else
 #include <c10/core/impl/InlineStreamGuard.h>
 #include <gcu/gcu_guard.h>
 #include <gcu/gcu_stream.h>
 #include <tops/tops_runtime_api.h>
+#endif
 #elif USE_SUNRISE_ADAPTOR
 #include <torch_ptpu/core/Stream.h>
 #endif
@@ -120,8 +125,15 @@ public:
         guard_(
             torch_txda::getStreamFromExternal(*(txStream_t *)stream, deviceId))
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+        guard_(*reinterpret_cast<topsStream_t *>(stream)),
+        previous_(reinterpret_cast<topsStream_t>(
+            GetCurrentStreamForDevice(deviceId))),
+        previousDevice_(0)
+#else
         guard_(
             torch_gcu::getStreamFromExternal(*(topsStream_t *)stream, deviceId))
+#endif
 // torch_ptpu intentionally does not expose a getStreamFromExternal-style API.
 // Instead we pick a stream from the pool, run torch ops on it, and rely on
 // flagcxBackend::syncStream() / flagcxPtpuEvent for cross-stream
@@ -131,11 +143,21 @@ public:
         guard_(torchpt::get_stream_from_pool(deviceId, /*prio=*/0))
 #endif
   {
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+    GetDevice(&previousDevice_);
+    SetDevice(deviceId_);
+    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(guard_));
+#endif
 #ifdef USE_SUNRISE_ADAPTOR
     torchpt::set_current_stream(guard_.unwrap());
 #endif
   }
-#ifdef USE_SUNRISE_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  ~flagcxStreamGuard() {
+    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(previous_));
+    SetDevice(previousDevice_);
+  }
+#elif USE_SUNRISE_ADAPTOR
   // torchpt::PTPUStream is a value type, not an RAII guard, so we have
   // to restore the previous current stream by hand on destruction.
   ~flagcxStreamGuard() {
@@ -184,8 +206,13 @@ public:
     guard_.reset_stream(
         torch_txda::getStreamFromExternal(*(txStream_t *)stream, deviceId_));
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+    guard_ = *reinterpret_cast<topsStream_t *>(stream);
+    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(guard_));
+#else
     guard_.reset_stream(
         torch_gcu::getStreamFromExternal(*(topsStream_t *)stream, deviceId_));
+#endif
 #elif USE_SUNRISE_ADAPTOR
     guard_ = torchpt::get_stream_from_pool(deviceId_, /*prio=*/0);
     torchpt::set_current_stream(guard_.unwrap());
@@ -222,7 +249,13 @@ private:
 #elif USE_TSM_ADAPTOR
   torch_txda::TXDAStreamGuard guard_;
 #elif USE_ENFLAME_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  topsStream_t guard_;
+  topsStream_t previous_;
+  int previousDevice_;
+#else
   torch_gcu::GCUStreamGuard guard_;
+#endif
 #elif USE_SUNRISE_ADAPTOR
   torchpt::PTPUStream sunrisePrevStream_;
   torchpt::PTPUStream guard_;

--- a/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
+++ b/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
@@ -7,7 +7,12 @@
 
 #include "flagcx.h"
 
-#ifdef USE_NVIDIA_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+#if !defined(USE_ASCEND_ADAPTOR) && !defined(USE_ENFLAME_ADAPTOR)
+#error "The FlagOS torch backend supports only Ascend and Enflame"
+#endif
+#include <flagos.h>
+#elif USE_NVIDIA_ADAPTOR
 #include <c10/core/impl/InlineStreamGuard.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/impl/CUDAGuardImpl.h>
@@ -54,15 +59,10 @@
 #include <c10/core/impl/InlineStreamGuard.h>
 #include <tx_runtime.h>
 #elif USE_ENFLAME_ADAPTOR
-#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
-#include <flagos.h>
-#include <tops/tops_runtime_api.h>
-#else
 #include <c10/core/impl/InlineStreamGuard.h>
 #include <gcu/gcu_guard.h>
 #include <gcu/gcu_stream.h>
 #include <tops/tops_runtime_api.h>
-#endif
 #elif USE_SUNRISE_ADAPTOR
 #include <torch_ptpu/core/Stream.h>
 #endif
@@ -96,7 +96,10 @@ public:
   explicit flagcxStreamGuard() = delete;
   explicit flagcxStreamGuard(flagcxStream_t stream, const int deviceId)
       : originalStream_(stream), currentStream_(nullptr), deviceId_(deviceId),
-#ifdef USE_NVIDIA_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+        guard_(*reinterpret_cast<Stream_t *>(stream)),
+        previous_(GetCurrentStreamForDevice(deviceId)), previousDevice_(0)
+#elif USE_NVIDIA_ADAPTOR
         guard_(
             at::cuda::getStreamFromExternal(*(cudaStream_t *)stream, deviceId))
 #elif USE_ILUVATAR_COREX_ADAPTOR
@@ -125,15 +128,8 @@ public:
         guard_(
             torch_txda::getStreamFromExternal(*(txStream_t *)stream, deviceId))
 #elif USE_ENFLAME_ADAPTOR
-#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
-        guard_(*reinterpret_cast<topsStream_t *>(stream)),
-        previous_(reinterpret_cast<topsStream_t>(
-            GetCurrentStreamForDevice(deviceId))),
-        previousDevice_(0)
-#else
         guard_(
             torch_gcu::getStreamFromExternal(*(topsStream_t *)stream, deviceId))
-#endif
 // torch_ptpu intentionally does not expose a getStreamFromExternal-style API.
 // Instead we pick a stream from the pool, run torch ops on it, and rely on
 // flagcxBackend::syncStream() / flagcxPtpuEvent for cross-stream
@@ -146,7 +142,7 @@ public:
 #ifdef FLAGCX_TORCH_BACKEND_FLAGOS
     GetDevice(&previousDevice_);
     SetDevice(deviceId_);
-    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(guard_));
+    SetCurrentStreamForDevice(deviceId_, guard_);
 #endif
 #ifdef USE_SUNRISE_ADAPTOR
     torchpt::set_current_stream(guard_.unwrap());
@@ -154,7 +150,7 @@ public:
   }
 #ifdef FLAGCX_TORCH_BACKEND_FLAGOS
   ~flagcxStreamGuard() {
-    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(previous_));
+    SetCurrentStreamForDevice(deviceId_, previous_);
     SetDevice(previousDevice_);
   }
 #elif USE_SUNRISE_ADAPTOR
@@ -176,7 +172,10 @@ public:
   flagcxStreamGuard &operator=(flagcxStreamGuard &&) = delete;
 
   void reset_stream(flagcxStream_t stream) {
-#ifdef USE_NVIDIA_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+    guard_ = *reinterpret_cast<Stream_t *>(stream);
+    SetCurrentStreamForDevice(deviceId_, guard_);
+#elif USE_NVIDIA_ADAPTOR
     guard_.reset_stream(
         at::cuda::getStreamFromExternal(*(cudaStream_t *)stream, deviceId_));
 #elif USE_ILUVATAR_COREX_ADAPTOR
@@ -206,13 +205,8 @@ public:
     guard_.reset_stream(
         torch_txda::getStreamFromExternal(*(txStream_t *)stream, deviceId_));
 #elif USE_ENFLAME_ADAPTOR
-#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
-    guard_ = *reinterpret_cast<topsStream_t *>(stream);
-    SetCurrentStreamForDevice(deviceId_, reinterpret_cast<Stream_t>(guard_));
-#else
     guard_.reset_stream(
         torch_gcu::getStreamFromExternal(*(topsStream_t *)stream, deviceId_));
-#endif
 #elif USE_SUNRISE_ADAPTOR
     guard_ = torchpt::get_stream_from_pool(deviceId_, /*prio=*/0);
     torchpt::set_current_stream(guard_.unwrap());
@@ -228,7 +222,11 @@ private:
   flagcxStream_t originalStream_;
   flagcxStream_t currentStream_;
   int deviceId_;
-#ifdef USE_NVIDIA_ADAPTOR
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  Stream_t guard_;
+  Stream_t previous_;
+  int previousDevice_;
+#elif USE_NVIDIA_ADAPTOR
   c10::cuda::CUDAStreamGuard guard_;
 #elif USE_ILUVATAR_COREX_ADAPTOR
   c10::cuda::CUDAStreamGuard guard_;
@@ -249,13 +247,7 @@ private:
 #elif USE_TSM_ADAPTOR
   torch_txda::TXDAStreamGuard guard_;
 #elif USE_ENFLAME_ADAPTOR
-#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
-  topsStream_t guard_;
-  topsStream_t previous_;
-  int previousDevice_;
-#else
   torch_gcu::GCUStreamGuard guard_;
-#endif
 #elif USE_SUNRISE_ADAPTOR
   torchpt::PTPUStream sunrisePrevStream_;
   torchpt::PTPUStream guard_;

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -722,10 +722,11 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
       flagcxStreamGuard guard(stream, device.index());
       for (const auto j : c10::irange(outputTensorsTmp.size())) {
         C10D_FLAGCX_CHECK(
-            devHandle_->deviceMemcpy(
-                outputTensorsTmp[j].data_ptr(), outputFlattened[j].data_ptr(),
-                outputTensorsTmp[j].numel() * outputTensorsTmp[j].element_size(),
-                flagcxMemcpyDeviceToDevice, stream),
+            devHandle_->deviceMemcpy(outputTensorsTmp[j].data_ptr(),
+                                     outputFlattened[j].data_ptr(),
+                                     outputTensorsTmp[j].numel() *
+                                         outputTensorsTmp[j].element_size(),
+                                     flagcxMemcpyDeviceToDevice, stream),
             std::nullopt);
       }
     }

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -266,14 +266,32 @@ bool flagcxWork::isCompleted() { return future_->completed(); }
 bool flagcxWork::isSuccess() const { return future_->hasValue(); }
 
 bool flagcxWork::wait(std::chrono::milliseconds /* unused */) {
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  int previousDevice = 0;
+  C10D_FLAGCX_CHECK(devHandle_->getDevice(&previousDevice), std::nullopt);
+  C10D_FLAGCX_CHECK(devHandle_->setDevice(deviceId_), std::nullopt);
+  try {
+    event_->block(deviceId_);
+    C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream_), std::nullopt);
+  } catch (...) {
+    devHandle_->setDevice(previousDevice);
+    throw;
+  }
+  C10D_FLAGCX_CHECK(devHandle_->setDevice(previousDevice), std::nullopt);
+#else
   event_->block(deviceId_);
   if (isBarrierOp_) {
     C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream_), std::nullopt);
   }
+#endif
+  stashedTensors_.clear();
   return true;
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> flagcxWork::getFuture() {
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  wait();
+#endif
   return future_;
 }
 
@@ -666,6 +684,7 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
   initComm(device);
   syncStream(device);
 
+  at::Tensor outputFlattened;
   if (!check_same_size(outputTensorsTmp)) {
     // Implement allgather with different sizes using broadcast
     const auto num_reduces = outputTensorsTmp.size();
@@ -680,7 +699,7 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
     }
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
-    at::Tensor outputFlattened = newLikeFlat(outputTensorsTmp);
+    outputFlattened = newLikeFlat(outputTensorsTmp);
 
 #if (defined(USE_NVIDIA_ADAPTOR) || defined(USE_METAX_ADAPTOR)) &&             \
     defined(TORCH_VER_GE_250)
@@ -696,11 +715,18 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
                         inputTensor.numel(), flagcxDataType, comm_, stream),
         std::nullopt);
 
-    // Copy the flattened tensor back into a vector of tensors.
+    // Copy the contiguous receive buffer back without dispatching an ATen
+    // copy kernel. GCU's int64 copy path is not reliable, and DDP uses int64
+    // tensors for parameter-shape verification.
     {
       flagcxStreamGuard guard(stream, device.index());
       for (const auto j : c10::irange(outputTensorsTmp.size())) {
-        outputTensorsTmp[j].copy_(outputFlattened[j], true);
+        C10D_FLAGCX_CHECK(
+            devHandle_->deviceMemcpy(
+                outputTensorsTmp[j].data_ptr(), outputFlattened[j].data_ptr(),
+                outputTensorsTmp[j].numel() * outputTensorsTmp[j].element_size(),
+                flagcxMemcpyDeviceToDevice, stream),
+            std::nullopt);
       }
     }
   }
@@ -709,6 +735,12 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
       c10::make_intrusive<flagcxWork>(OpType::ALLGATHER, stream, devHandle_);
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  if (outputFlattened.defined()) {
+    work->stashedTensors_.push_back(std::move(outputFlattened));
+  }
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream), std::nullopt);
+#endif
   // Create a future to track the allgather operation
   std::vector<at::Device> devices{inputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -915,6 +947,8 @@ flagcxBackend::alltoall(std::vector<at::Tensor> &outputTensors,
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  work->stashedTensors_.push_back(std::move(inputFlattened));
+  work->stashedTensors_.push_back(std::move(outputFlattened));
   // Create a future to track the alltoall operation
   std::vector<at::Device> devices{device};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1093,6 +1127,7 @@ flagcxBackend::gather(std::vector<std::vector<at::Tensor>> &outputTensors,
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  work->stashedTensors_.push_back(std::move(outputFlattened));
   // Create a future to track the gather operation
   std::vector<at::Device> devices{inputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1155,12 +1190,13 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce_scatter(
   initComm(device);
   syncStream(device);
 
+  at::Tensor inputFlattened;
   if (!check_same_size(inputTensorsTmp)) {
     throw std::runtime_error(
         "flagcx only support same size reducescatter operation");
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
-    at::Tensor inputFlattened = newLikeFlat(inputTensorsTmp);
+    inputFlattened = newLikeFlat(inputTensorsTmp);
 
     // Copy the input tensors to the flattened tensor.
     {
@@ -1189,6 +1225,7 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce_scatter(
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  work->stashedTensors_.push_back(std::move(inputFlattened));
   // Create a future to track the reducescatter operation
   std::vector<at::Device> devices{outputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1322,6 +1359,7 @@ flagcxBackend::scatter(std::vector<at::Tensor> &outputTensors,
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
+  work->stashedTensors_.push_back(std::move(inputFlattened));
   // Create a future to track the scatter operation
   std::vector<at::Device> devices{outputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -100,6 +100,39 @@ bool check_same_size(const std::vector<at::Tensor> &inputTensors) {
   return true;
 }
 
+at::Tensor newLikeFlatOnStream(std::vector<at::Tensor> &tensors,
+                               flagcxStream_t stream, int deviceId) {
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  // torch-fl's caching allocator associates new allocations with the current
+  // device stream. Allocate flattened intermediates on the communication
+  // stream so that releasing their Tensor handles cannot recycle the storage
+  // before the queued collective and copy operations have completed.
+  flagcxStreamGuard guard(stream, deviceId);
+#endif
+  return newLikeFlat(tensors);
+}
+
+void copyTensorOnStream(at::Tensor dst, const at::Tensor &src,
+                        flagcxStream_t stream,
+                        flagcxDeviceHandle_t devHandle, int deviceId) {
+  TORCH_CHECK(dst.numel() == src.numel(),
+              "FlagCX tensor copy requires equal element counts");
+  TORCH_CHECK(dst.scalar_type() == src.scalar_type(),
+              "FlagCX tensor copy requires equal data types");
+#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+  TORCH_CHECK(dst.is_contiguous() && src.is_contiguous(),
+              "FlagOS collective intermediates must be contiguous");
+  C10D_FLAGCX_CHECK(
+      devHandle->deviceMemcpy(dst.data_ptr(), src.data_ptr(),
+                              dst.numel() * dst.element_size(),
+                              flagcxMemcpyDeviceToDevice, stream),
+      std::nullopt);
+#else
+  flagcxStreamGuard guard(stream, deviceId);
+  dst.copy_(src, true);
+#endif
+}
+
 void check_device(at::Device dev1, at::Device dev2) {
 #ifdef USE_CAMBRICON_ADAPTOR
   if (dev1.is_privateuseone() && dev2.is_privateuseone() && dev1 != dev2) {
@@ -266,12 +299,11 @@ bool flagcxWork::isCompleted() { return future_->completed(); }
 bool flagcxWork::isSuccess() const { return future_->hasValue(); }
 
 bool flagcxWork::wait(std::chrono::milliseconds /* unused */) {
-#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+#if defined(FLAGCX_TORCH_BACKEND_FLAGOS) && defined(USE_ENFLAME_ADAPTOR)
   int previousDevice = 0;
   C10D_FLAGCX_CHECK(devHandle_->getDevice(&previousDevice), std::nullopt);
   C10D_FLAGCX_CHECK(devHandle_->setDevice(deviceId_), std::nullopt);
   try {
-    event_->block(deviceId_);
     C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream_), std::nullopt);
   } catch (...) {
     devHandle_->setDevice(previousDevice);
@@ -284,12 +316,11 @@ bool flagcxWork::wait(std::chrono::milliseconds /* unused */) {
     C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream_), std::nullopt);
   }
 #endif
-  stashedTensors_.clear();
   return true;
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> flagcxWork::getFuture() {
-#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
+#if defined(FLAGCX_TORCH_BACKEND_FLAGOS) && defined(USE_ENFLAME_ADAPTOR)
   wait();
 #endif
   return future_;
@@ -355,7 +386,7 @@ flagcxStream_t flagcxBackend::getStreamByIndex(int streamId) {
     return search->second;
   } else {
     flagcxStreams_[streamId] = nullptr;
-#ifdef USE_ASCEND_ADAPTOR
+#if defined(USE_ASCEND_ADAPTOR) && !defined(FLAGCX_TORCH_BACKEND_FLAGOS)
     // TODO: The getStreamFromExternal interface is not supported at this stage
     // on NPU. Adaptation modifications will be made in the future.
     acl_stream = c10_npu::getCurrentNPUStream().stream(false);
@@ -684,7 +715,6 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
   initComm(device);
   syncStream(device);
 
-  at::Tensor outputFlattened;
   if (!check_same_size(outputTensorsTmp)) {
     // Implement allgather with different sizes using broadcast
     const auto num_reduces = outputTensorsTmp.size();
@@ -699,7 +729,8 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
     }
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
-    outputFlattened = newLikeFlat(outputTensorsTmp);
+    at::Tensor outputFlattened =
+        newLikeFlatOnStream(outputTensorsTmp, stream, device.index());
 
 #if (defined(USE_NVIDIA_ADAPTOR) || defined(USE_METAX_ADAPTOR)) &&             \
     defined(TORCH_VER_GE_250)
@@ -715,19 +746,12 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
                         inputTensor.numel(), flagcxDataType, comm_, stream),
         std::nullopt);
 
-    // Copy the contiguous receive buffer back without dispatching an ATen
-    // copy kernel. GCU's int64 copy path is not reliable, and DDP uses int64
-    // tensors for parameter-shape verification.
+    // Copy the flattened tensor back into a vector of tensors.
     {
       flagcxStreamGuard guard(stream, device.index());
       for (const auto j : c10::irange(outputTensorsTmp.size())) {
-        C10D_FLAGCX_CHECK(
-            devHandle_->deviceMemcpy(outputTensorsTmp[j].data_ptr(),
-                                     outputFlattened[j].data_ptr(),
-                                     outputTensorsTmp[j].numel() *
-                                         outputTensorsTmp[j].element_size(),
-                                     flagcxMemcpyDeviceToDevice, stream),
-            std::nullopt);
+        copyTensorOnStream(outputTensorsTmp[j], outputFlattened[j], stream,
+                         devHandle_, device.index());
       }
     }
   }
@@ -736,12 +760,6 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
       c10::make_intrusive<flagcxWork>(OpType::ALLGATHER, stream, devHandle_);
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
-  if (outputFlattened.defined()) {
-    work->stashedTensors_.push_back(std::move(outputFlattened));
-  }
-#ifdef FLAGCX_TORCH_BACKEND_FLAGOS
-  C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream), std::nullopt);
-#endif
   // Create a future to track the allgather operation
   std::vector<at::Device> devices{inputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -913,14 +931,17 @@ flagcxBackend::alltoall(std::vector<at::Tensor> &outputTensors,
   syncStream(device);
 
   // Flatten a vector of tensors into a single, stacked tensor.
-  at::Tensor inputFlattened = newLikeFlat(inputTensors);
-  at::Tensor outputFlattened = newLikeFlat(outputTensors);
+  at::Tensor inputFlattened =
+      newLikeFlatOnStream(inputTensors, stream, device.index());
+  at::Tensor outputFlattened =
+      newLikeFlatOnStream(outputTensors, stream, device.index());
 
   // Copy the input tensors to the flattened tensor.
   {
     flagcxStreamGuard guard(stream, device.index());
     for (const auto j : c10::irange(inputTensors.size())) {
-      inputFlattened[j].copy_(inputTensors[j], true);
+      copyTensorOnStream(inputFlattened[j], inputTensors[j], stream,
+                         devHandle_, device.index());
     }
   }
 
@@ -942,14 +963,13 @@ flagcxBackend::alltoall(std::vector<at::Tensor> &outputTensors,
   {
     flagcxStreamGuard guard(stream, device.index());
     for (const auto j : c10::irange(outputTensors.size())) {
-      outputTensors[j].copy_(outputFlattened[j], true);
+      copyTensorOnStream(outputTensors[j], outputFlattened[j], stream,
+                         devHandle_, device.index());
     }
   }
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
-  work->stashedTensors_.push_back(std::move(inputFlattened));
-  work->stashedTensors_.push_back(std::move(outputFlattened));
   // Create a future to track the alltoall operation
   std::vector<at::Device> devices{device};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1103,7 +1123,17 @@ flagcxBackend::gather(std::vector<std::vector<at::Tensor>> &outputTensors,
   }
 
   // Flatten a vector of tensors into a single, stacked tensor.
-  at::Tensor outputFlattened = newLikeFlat(outputTensorsTmp);
+#if defined(FLAGCX_TORCH_BACKEND_FLAGOS) && defined(USE_ENFLAME_ADAPTOR)
+  auto outputTemplates = outputTensorsTmp;
+  if (rank_ != root) {
+    outputTemplates.resize(size_, inputTensor);
+  }
+  at::Tensor outputFlattened =
+      newLikeFlatOnStream(outputTemplates, stream, device.index());
+#else
+  at::Tensor outputFlattened =
+      newLikeFlatOnStream(outputTensorsTmp, stream, device.index());
+#endif
 
 #if (defined(USE_NVIDIA_ADAPTOR) || defined(USE_METAX_ADAPTOR)) &&             \
     defined(TORCH_VER_GE_250)
@@ -1112,23 +1142,32 @@ flagcxBackend::gather(std::vector<std::vector<at::Tensor>> &outputTensors,
   }
 
 #endif
-  // Perform the gather operation
+  // Perform the gather operation. The tested ECCL runtime does not populate
+  // the root receive buffer for gather, so use its working all-gather primitive
+  // and expose the result only on the root, preserving PyTorch semantics.
+#if defined(FLAGCX_TORCH_BACKEND_FLAGOS) && defined(USE_ENFLAME_ADAPTOR)
+  C10D_FLAGCX_CHECK(
+      flagcxAllGather(inputTensor.data_ptr(), outputFlattened.data_ptr(),
+                      inputTensor.numel(), flagcxDataType, comm_, stream),
+      std::nullopt);
+#else
   C10D_FLAGCX_CHECK(
       flagcxGather(inputTensor.data_ptr(), outputFlattened.data_ptr(),
                    inputTensor.numel(), flagcxDataType, root, comm_, stream),
       std::nullopt);
+#endif
 
   // Unflatten the flattened tensor back into a vector of tensors.
   if (rank_ == root) {
     flagcxStreamGuard guard(stream, device.index());
     for (const auto j : c10::irange(outputTensorsTmp.size())) {
-      outputTensorsTmp[j].copy_(outputFlattened[j], true);
+      copyTensorOnStream(outputTensorsTmp[j], outputFlattened[j], stream,
+                         devHandle_, device.index());
     }
   }
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
-  work->stashedTensors_.push_back(std::move(outputFlattened));
   // Create a future to track the gather operation
   std::vector<at::Device> devices{inputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1191,19 +1230,20 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce_scatter(
   initComm(device);
   syncStream(device);
 
-  at::Tensor inputFlattened;
   if (!check_same_size(inputTensorsTmp)) {
     throw std::runtime_error(
         "flagcx only support same size reducescatter operation");
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
-    inputFlattened = newLikeFlat(inputTensorsTmp);
+    at::Tensor inputFlattened =
+        newLikeFlatOnStream(inputTensorsTmp, stream, device.index());
 
     // Copy the input tensors to the flattened tensor.
     {
       flagcxStreamGuard guard(stream, device.index());
       for (const auto j : c10::irange(inputTensorsTmp.size())) {
-        inputFlattened[j].copy_(inputTensorsTmp[j], true);
+        copyTensorOnStream(inputFlattened[j], inputTensorsTmp[j], stream,
+                           devHandle_, device.index());
       }
     }
 
@@ -1226,7 +1266,6 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce_scatter(
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
-  work->stashedTensors_.push_back(std::move(inputFlattened));
   // Create a future to track the reducescatter operation
   std::vector<at::Device> devices{outputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(
@@ -1334,13 +1373,24 @@ flagcxBackend::scatter(std::vector<at::Tensor> &outputTensors,
   }
 
   // Flatten a vector of tensors into a single, stacked tensor.
-  at::Tensor inputFlattened = newLikeFlat(inputTensorsTmp);
+#if defined(FLAGCX_TORCH_BACKEND_FLAGOS) && defined(USE_ENFLAME_ADAPTOR)
+  auto inputTemplates = inputTensorsTmp;
+  if (rank_ != root) {
+    inputTemplates.resize(size_, outputTensor);
+  }
+  at::Tensor inputFlattened =
+      newLikeFlatOnStream(inputTemplates, stream, device.index());
+#else
+  at::Tensor inputFlattened =
+      newLikeFlatOnStream(inputTensorsTmp, stream, device.index());
+#endif
 
   // Copy the input tensors to the flattened tensor.
   if (rank_ == root) {
     flagcxStreamGuard guard(stream, device.index());
     for (const auto j : c10::irange(inputTensorsTmp.size())) {
-      inputFlattened[j].copy_(inputTensorsTmp[j], true);
+      copyTensorOnStream(inputFlattened[j], inputTensorsTmp[j], stream,
+                         devHandle_, device.index());
     }
   }
 
@@ -1352,15 +1402,27 @@ flagcxBackend::scatter(std::vector<at::Tensor> &outputTensors,
 
 #endif
 
-  // Perform the scatter operation
+  // Perform the scatter operation. The tested ECCL runtime does not populate
+  // scatter outputs, so broadcast each root input and retain this rank's slot.
+#if defined(FLAGCX_TORCH_BACKEND_FLAGOS) && defined(USE_ENFLAME_ADAPTOR)
+  for (const auto peer : c10::irange(size_)) {
+    C10D_FLAGCX_CHECK(
+        flagcxBroadcast(inputFlattened[peer].data_ptr(),
+                        inputFlattened[peer].data_ptr(), outputTensor.numel(),
+                        flagcxDataType, root, comm_, stream),
+        std::nullopt);
+  }
+  copyTensorOnStream(outputTensor, inputFlattened[rank_], stream, devHandle_,
+                     device.index());
+#else
   C10D_FLAGCX_CHECK(flagcxScatter(inputFlattened.data_ptr(),
                                   outputTensor.data_ptr(), outputTensor.numel(),
                                   flagcxDataType, root, comm_, stream),
                     std::nullopt);
+#endif
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
-  work->stashedTensors_.push_back(std::move(inputFlattened));
   // Create a future to track the scatter operation
   std::vector<at::Device> devices{outputTensor.device()};
   work->future_ = c10::make_intrusive<c10::ivalue::Future>(

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -113,8 +113,8 @@ at::Tensor newLikeFlatOnStream(std::vector<at::Tensor> &tensors,
 }
 
 void copyTensorOnStream(at::Tensor dst, const at::Tensor &src,
-                        flagcxStream_t stream,
-                        flagcxDeviceHandle_t devHandle, int deviceId) {
+                        flagcxStream_t stream, flagcxDeviceHandle_t devHandle,
+                        int deviceId) {
   TORCH_CHECK(dst.numel() == src.numel(),
               "FlagCX tensor copy requires equal element counts");
   TORCH_CHECK(dst.scalar_type() == src.scalar_type(),
@@ -122,11 +122,10 @@ void copyTensorOnStream(at::Tensor dst, const at::Tensor &src,
 #ifdef FLAGCX_TORCH_BACKEND_FLAGOS
   TORCH_CHECK(dst.is_contiguous() && src.is_contiguous(),
               "FlagOS collective intermediates must be contiguous");
-  C10D_FLAGCX_CHECK(
-      devHandle->deviceMemcpy(dst.data_ptr(), src.data_ptr(),
-                              dst.numel() * dst.element_size(),
-                              flagcxMemcpyDeviceToDevice, stream),
-      std::nullopt);
+  C10D_FLAGCX_CHECK(devHandle->deviceMemcpy(dst.data_ptr(), src.data_ptr(),
+                                            dst.numel() * dst.element_size(),
+                                            flagcxMemcpyDeviceToDevice, stream),
+                    std::nullopt);
 #else
   flagcxStreamGuard guard(stream, deviceId);
   dst.copy_(src, true);
@@ -751,7 +750,7 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
       flagcxStreamGuard guard(stream, device.index());
       for (const auto j : c10::irange(outputTensorsTmp.size())) {
         copyTensorOnStream(outputTensorsTmp[j], outputFlattened[j], stream,
-                         devHandle_, device.index());
+                           devHandle_, device.index());
       }
     }
   }
@@ -940,8 +939,8 @@ flagcxBackend::alltoall(std::vector<at::Tensor> &outputTensors,
   {
     flagcxStreamGuard guard(stream, device.index());
     for (const auto j : c10::irange(inputTensors.size())) {
-      copyTensorOnStream(inputFlattened[j], inputTensors[j], stream,
-                         devHandle_, device.index());
+      copyTensorOnStream(inputFlattened[j], inputTensors[j], stream, devHandle_,
+                         device.index());
     }
   }
 
@@ -1406,11 +1405,11 @@ flagcxBackend::scatter(std::vector<at::Tensor> &outputTensors,
   // scatter outputs, so broadcast each root input and retain this rank's slot.
 #if defined(FLAGCX_TORCH_BACKEND_FLAGOS) && defined(USE_ENFLAME_ADAPTOR)
   for (const auto peer : c10::irange(size_)) {
-    C10D_FLAGCX_CHECK(
-        flagcxBroadcast(inputFlattened[peer].data_ptr(),
-                        inputFlattened[peer].data_ptr(), outputTensor.numel(),
-                        flagcxDataType, root, comm_, stream),
-        std::nullopt);
+    C10D_FLAGCX_CHECK(flagcxBroadcast(inputFlattened[peer].data_ptr(),
+                                      inputFlattened[peer].data_ptr(),
+                                      outputTensor.numel(), flagcxDataType,
+                                      root, comm_, stream),
+                      std::nullopt);
   }
   copyTensorOnStream(outputTensor, inputFlattened[rank_], stream, devHandle_,
                      device.index());

--- a/plugin/torch/setup.py
+++ b/plugin/torch/setup.py
@@ -16,6 +16,7 @@ from _build_config import (
     detect_adaptor,
     detect_torch_flag,
     get_device_config,
+    get_device_rpath_dirs,
     get_ext_classes,
 )
 
@@ -24,6 +25,10 @@ print(f"Using {adaptor} adaptor")
 
 adaptor_flag = ADAPTOR_MAP[adaptor]
 torch_flag = detect_torch_flag()
+torch_backend_flags = []
+if adaptor == "enflame" and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
+    # Compile the Enflame plugin against torch_fl's C ABI instead of torch_gcu.
+    torch_backend_flags.append("-DFLAGCX_TORCH_BACKEND_FLAGOS")
 
 plugin_dir = os.path.dirname(os.path.abspath(__file__))
 repo_root = os.path.join(plugin_dir, "..", "..")
@@ -56,10 +61,13 @@ if CppExtension is not None:
         sources=sources,
         include_dirs=include_dirs,
         extra_compile_args={
-            'cxx': [adaptor_flag, torch_flag]
+            'cxx': [adaptor_flag, torch_flag] + torch_backend_flags
         },
         extra_link_args=["-Wl,-rpath," + os.path.join(repo_root, "build", "lib")]
-                        + ["-Wl,-rpath," + d for d in dev_libdirs],
+                        + [
+                            "-Wl,-rpath," + d
+                            for d in get_device_rpath_dirs(adaptor_flag, dev_libdirs)
+                        ],
         library_dirs=library_dirs,
         libraries=libs,
     )

--- a/plugin/torch/setup.py
+++ b/plugin/torch/setup.py
@@ -18,6 +18,7 @@ from _build_config import (
     get_device_config,
     get_device_rpath_dirs,
     get_ext_classes,
+    resolve_torch_backend,
 )
 
 adaptor = detect_adaptor()
@@ -25,10 +26,9 @@ print(f"Using {adaptor} adaptor")
 
 adaptor_flag = ADAPTOR_MAP[adaptor]
 torch_flag = detect_torch_flag()
-torch_backend_flags = []
-if adaptor == "enflame" and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
-    # Compile the Enflame plugin against torch_fl's C ABI instead of torch_gcu.
-    torch_backend_flags.append("-DFLAGCX_TORCH_BACKEND_FLAGOS")
+torch_backend = resolve_torch_backend(adaptor)
+torch_backend_flags = list(torch_backend.compile_flags)
+print(f"Using {torch_backend.name} torch backend")
 
 plugin_dir = os.path.dirname(os.path.abspath(__file__))
 repo_root = os.path.join(plugin_dir, "..", "..")
@@ -47,7 +47,9 @@ library_dirs = [
 libs = ["flagcx"]
 
 # Add device-specific paths
-dev_includes, dev_libdirs, dev_libs = get_device_config(adaptor_flag)
+dev_includes, dev_libdirs, dev_libs = get_device_config(
+    adaptor_flag, torch_backend
+)
 include_dirs += dev_includes
 library_dirs += dev_libdirs
 libs += dev_libs
@@ -66,7 +68,9 @@ if CppExtension is not None:
         extra_link_args=["-Wl,-rpath," + os.path.join(repo_root, "build", "lib")]
                         + [
                             "-Wl,-rpath," + d
-                            for d in get_device_rpath_dirs(adaptor_flag, dev_libdirs)
+                            for d in get_device_rpath_dirs(
+                                adaptor_flag, dev_libdirs, torch_backend
+                            )
                         ],
         library_dirs=library_dirs,
         libraries=libs,

--- a/plugin/torch/tests/distributed_smoke.py
+++ b/plugin/torch/tests/distributed_smoke.py
@@ -1,0 +1,211 @@
+"""Two-rank hardware smoke test for vendor and FlagOS Torch backends.
+
+Run this file with torchrun after building the plugin for the selected adaptor
+and backend. It intentionally uses the same collective workflow in both modes.
+"""
+
+import argparse
+import importlib
+import os
+
+import torch
+import torch.distributed as dist
+
+
+VENDOR_PACKAGES = {
+    "ascend": ("torch_npu", "npu"),
+    "enflame": ("torch_gcu", "gcu"),
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--adaptor", choices=VENDOR_PACKAGES, required=True)
+    return parser.parse_args()
+
+
+def resolve_device_type(adaptor):
+    backend = os.environ.get("FLAGCX_TORCH_BACKEND", "vendor").strip().lower()
+    if backend == "flagos":
+        importlib.import_module("torch_fl")
+        return "flagos"
+    if backend != "vendor":
+        raise RuntimeError(f"Unsupported FLAGCX_TORCH_BACKEND={backend!r}")
+
+    package, device_type = VENDOR_PACKAGES[adaptor]
+    importlib.import_module(package)
+    return device_type
+
+
+def assert_tensor_equal(actual, expected):
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=0, atol=0)
+
+
+def churn_allocator(device, numel):
+    """Try to reuse a just-released flattened collective buffer."""
+    for value in range(32):
+        torch.full((numel,), -value, dtype=torch.float32, device=device)
+
+
+def main():
+    args = parse_args()
+    device_type = resolve_device_type(args.adaptor)
+
+    import flagcx  # noqa: F401 - registers the process-group backend
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    if world_size != 2:
+        raise RuntimeError("This smoke test requires exactly two ranks")
+
+    device_module = getattr(torch, device_type)
+    device_module.set_device(local_rank)
+    device = torch.device(device_type, local_rank)
+    dist.init_process_group(
+        f"cpu:gloo,{device_type}:flagcx",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    try:
+        value = torch.tensor([rank + 1], dtype=torch.float32, device=device)
+        work = dist.all_reduce(value, async_op=True)
+        work.wait()
+        assert_tensor_equal(value, torch.tensor([3.0]))
+
+        future_value = torch.tensor(
+            [rank + 1], dtype=torch.float32, device=device
+        )
+        future = dist.all_reduce(future_value, async_op=True).get_future()
+        future.wait()
+        assert_tensor_equal(future_value, torch.tensor([3.0]))
+
+        source = torch.tensor([rank], dtype=torch.int64, device=device)
+        gathered = [
+            torch.empty_like(source) for _ in range(world_size)
+        ]
+        work = dist.all_gather(gathered, source, async_op=True)
+        churn_allocator(device, world_size)
+        work.wait()
+        assert_tensor_equal(
+            torch.cat(gathered), torch.tensor([0, 1], dtype=torch.int64)
+        )
+
+        list_all_to_all_input = [
+            torch.tensor(
+                [rank * 10 + peer], dtype=torch.float32, device=device
+            )
+            for peer in range(world_size)
+        ]
+        list_all_to_all_output = [
+            torch.empty(1, dtype=torch.float32, device=device)
+            for _ in range(world_size)
+        ]
+        work = dist.all_to_all(
+            list_all_to_all_output,
+            list_all_to_all_input,
+            async_op=True,
+        )
+        churn_allocator(device, world_size)
+        work.wait()
+        assert_tensor_equal(
+            torch.cat(list_all_to_all_output),
+            torch.tensor([rank, rank + 10], dtype=torch.float32),
+        )
+
+        gather_input = torch.tensor(
+            [rank + 5], dtype=torch.float32, device=device
+        )
+        gather_output = (
+            [torch.empty_like(gather_input) for _ in range(world_size)]
+            if rank == 0
+            else None
+        )
+        work = dist.gather(
+            gather_input,
+            gather_list=gather_output,
+            dst=0,
+            async_op=True,
+        )
+        churn_allocator(device, world_size)
+        work.wait()
+        if rank == 0:
+            assert_tensor_equal(
+                torch.cat(gather_output),
+                torch.tensor([5, 6], dtype=torch.float32),
+            )
+
+        list_reduce_scatter_input = [
+            torch.tensor(
+                [rank * 10 + peer + 1],
+                dtype=torch.float32,
+                device=device,
+            )
+            for peer in range(world_size)
+        ]
+        list_reduce_scatter_output = torch.empty(
+            1, dtype=torch.float32, device=device
+        )
+        work = dist.reduce_scatter(
+            list_reduce_scatter_output,
+            list_reduce_scatter_input,
+            async_op=True,
+        )
+        churn_allocator(device, world_size)
+        work.wait()
+        expected = torch.tensor([12.0 if rank == 0 else 14.0])
+        assert_tensor_equal(list_reduce_scatter_output, expected)
+
+        scatter_output = torch.empty(1, dtype=torch.float32, device=device)
+        scatter_input = (
+            [
+                torch.tensor([21 + peer], dtype=torch.float32, device=device)
+                for peer in range(world_size)
+            ]
+            if rank == 0
+            else None
+        )
+        work = dist.scatter(
+            scatter_output,
+            scatter_list=scatter_input,
+            src=0,
+            async_op=True,
+        )
+        churn_allocator(device, world_size)
+        work.wait()
+        assert_tensor_equal(scatter_output, torch.tensor([21.0 + rank]))
+
+        scatter_input = torch.tensor(
+            [rank * 2 + 1, rank * 2 + 2],
+            dtype=torch.float32,
+            device=device,
+        )
+        scatter_output = torch.empty(1, dtype=torch.float32, device=device)
+        dist.reduce_scatter_tensor(scatter_output, scatter_input)
+        expected = torch.tensor([4.0 if rank == 0 else 6.0])
+        assert_tensor_equal(scatter_output, expected)
+
+        all_to_all_input = torch.tensor(
+            [rank * 10, rank * 10 + 1], dtype=torch.int64, device=device
+        )
+        all_to_all_output = torch.empty_like(all_to_all_input)
+        dist.all_to_all_single(all_to_all_output, all_to_all_input)
+        expected = torch.tensor(
+            [rank, rank + 10], dtype=torch.int64
+        )
+        assert_tensor_equal(all_to_all_output, expected)
+
+        barrier = dist.barrier(async_op=True)
+        barrier.wait()
+        if rank == 0:
+            print(
+                f"PASS: adaptor={args.adaptor} "
+                f"backend={os.environ.get('FLAGCX_TORCH_BACKEND', 'vendor')}"
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin/torch/tests/test_backend_loader.py
+++ b/plugin/torch/tests/test_backend_loader.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PACKAGE_DIR = Path(__file__).resolve().parents[1] / "flagcx"
+sys.path.insert(0, str(PACKAGE_DIR))
+
+import _backend_loader as backend_loader
+
+
+class BackendLoaderTest(unittest.TestCase):
+    def backend_environment(self, value=None):
+        environment = dict(os.environ)
+        environment.pop("FLAGCX_TORCH_BACKEND", None)
+        if value is not None:
+            environment["FLAGCX_TORCH_BACKEND"] = value
+        return mock.patch.dict(os.environ, environment, clear=True)
+
+    def test_vendor_is_the_runtime_default(self):
+        with self.backend_environment():
+            self.assertEqual(backend_loader.selected_torch_backend(), "vendor")
+
+    def test_flagos_loads_only_torch_fl(self):
+        with self.backend_environment("flagos"), mock.patch.object(
+            backend_loader.importlib, "import_module"
+        ) as import_module:
+            loaded = backend_loader.load_torch_device_backend()
+
+        self.assertEqual(loaded, "torch_fl")
+        import_module.assert_called_once_with("torch_fl")
+
+    def test_vendor_keeps_existing_probe_order(self):
+        def import_package(package):
+            if package == "torch_gcu":
+                return mock.sentinel.torch_gcu
+            raise ImportError(package)
+
+        with self.backend_environment("vendor"), mock.patch.object(
+            backend_loader.importlib,
+            "import_module",
+            side_effect=import_package,
+        ) as import_module:
+            loaded = backend_loader.load_torch_device_backend()
+
+        self.assertEqual(loaded, "torch_gcu")
+        self.assertEqual(
+            [call.args[0] for call in import_module.call_args_list],
+            ["torch_npu", "torch_mlu", "torch_musa", "torch_txda", "torch_gcu"],
+        )
+
+    def test_invalid_backend_is_rejected_before_import(self):
+        with self.backend_environment("torch_npu"), mock.patch.object(
+            backend_loader.importlib, "import_module"
+        ) as import_module:
+            with self.assertRaisesRegex(RuntimeError, "Valid values"):
+                backend_loader.load_torch_device_backend()
+
+        import_module.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin/torch/tests/test_backend_source.py
+++ b/plugin/torch/tests/test_backend_source.py
@@ -1,0 +1,92 @@
+import re
+import unittest
+from pathlib import Path
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+SOURCE = (PLUGIN_DIR / "flagcx/src/backend_flagcx.cpp").read_text()
+HEADER = (PLUGIN_DIR / "flagcx/include/backend_flagcx.hpp").read_text()
+
+
+def function_body(source, signature, next_signature):
+    start = source.index(signature)
+    end = source.index(next_signature, start)
+    return source[start:end]
+
+
+class BackendSourceRegressionTest(unittest.TestCase):
+    def test_ascend_flagos_does_not_reference_torch_npu_stream(self):
+        get_stream = function_body(
+            SOURCE,
+            "flagcxStream_t flagcxBackend::getStreamByIndex",
+            "std::unique_ptr<flagcxEvent>",
+        )
+
+        self.assertRegex(
+            get_stream,
+            re.compile(
+                r"defined\(USE_ASCEND_ADAPTOR\).*"
+                r"!defined\(FLAGCX_TORCH_BACKEND_FLAGOS\).*"
+                r"c10_npu::getCurrentNPUStream",
+                re.DOTALL,
+            ),
+        )
+        self.assertIn("devHandle_->streamCreate", get_stream)
+        self.assertRegex(
+            HEADER,
+            re.compile(
+                r"defined\(USE_ASCEND_ADAPTOR\).*"
+                r"!defined\(FLAGCX_TORCH_BACKEND_FLAGOS\).*aclrtStream",
+                re.DOTALL,
+            ),
+        )
+
+    def test_flattened_intermediates_are_allocated_on_flagos_comm_stream(self):
+        helper = function_body(
+            SOURCE,
+            "at::Tensor newLikeFlatOnStream",
+            "void copyTensorOnStream",
+        )
+
+        self.assertIn("#ifdef FLAGCX_TORCH_BACKEND_FLAGOS", helper)
+        self.assertIn("flagcxStreamGuard guard(stream, deviceId)", helper)
+        self.assertEqual(SOURCE.count("newLikeFlatOnStream("), 9)
+        self.assertEqual(SOURCE.count("newLikeFlat("), 1)
+
+    def test_flagos_intermediate_copies_use_device_memcpy(self):
+        helper = function_body(
+            SOURCE,
+            "void copyTensorOnStream",
+            "void check_device",
+        )
+
+        self.assertIn("#ifdef FLAGCX_TORCH_BACKEND_FLAGOS", helper)
+        self.assertIn("devHandle->deviceMemcpy", helper)
+        self.assertIn("flagcxMemcpyDeviceToDevice", helper)
+        self.assertEqual(SOURCE.count("copyTensorOnStream("), 8)
+
+    def test_enflame_gather_and_scatter_avoid_broken_eccl_primitives(self):
+        gather = function_body(
+            SOURCE,
+            "flagcxBackend::gather",
+            "c10::intrusive_ptr<Work> flagcxBackend::reduce",
+        )
+        scatter = function_body(
+            SOURCE,
+            "flagcxBackend::scatter",
+            "c10::intrusive_ptr<Work> flagcxBackend::send",
+        )
+
+        for body in (gather, scatter):
+            self.assertIn(
+                "defined(FLAGCX_TORCH_BACKEND_FLAGOS) && defined(USE_ENFLAME_ADAPTOR)",
+                body,
+            )
+        self.assertIn("flagcxAllGather", gather)
+        self.assertIn("flagcxGather", gather)
+        self.assertIn("flagcxBroadcast", scatter)
+        self.assertIn("flagcxScatter", scatter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin/torch/tests/test_build_config.py
+++ b/plugin/torch/tests/test_build_config.py
@@ -1,0 +1,154 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_DIR))
+
+import _build_config as build_config
+
+
+BACKEND_ENV_VARS = {
+    "FLAGCX_TORCH_BACKEND",
+    "FLAGOS_INSTALL_PATH",
+    "FLAGOS_INCLUDE_DIR",
+    "FLAGOS_LIBRARY_DIR",
+    "ASCEND_HOME_PATH",
+    "DEVICE_HOME",
+}
+
+
+class TorchBackendConfigTest(unittest.TestCase):
+    def clean_environment(self, **values):
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in BACKEND_ENV_VARS
+        }
+        environment.update(values)
+        return mock.patch.dict(os.environ, environment, clear=True)
+
+    def test_vendor_is_the_default(self):
+        with self.clean_environment():
+            ascend = build_config.resolve_torch_backend("ascend")
+            enflame = build_config.resolve_torch_backend("enflame")
+
+        self.assertEqual(ascend.name, "vendor")
+        self.assertEqual(ascend.python_package, "torch_npu")
+        self.assertEqual(ascend.device_name, "npu")
+        self.assertEqual(ascend.compile_flags, ())
+        self.assertEqual(enflame.name, "vendor")
+        self.assertEqual(enflame.python_package, "torch_gcu")
+        self.assertEqual(enflame.device_name, "gcu")
+        self.assertEqual(enflame.compile_flags, ())
+
+    def test_flagos_support_matrix(self):
+        with self.clean_environment(FLAGCX_TORCH_BACKEND="flagos"):
+            for adaptor in ("ascend", "enflame"):
+                backend = build_config.resolve_torch_backend(adaptor)
+                self.assertEqual(backend.name, "flagos")
+                self.assertEqual(backend.python_package, "torch_fl")
+                self.assertEqual(backend.device_name, "flagos")
+                self.assertEqual(
+                    backend.compile_flags,
+                    ("-DFLAGCX_TORCH_BACKEND_FLAGOS",),
+                )
+
+            with self.assertRaisesRegex(RuntimeError, "supports only"):
+                build_config.resolve_torch_backend("nvidia")
+
+    def test_invalid_backend_is_rejected(self):
+        with self.clean_environment(FLAGCX_TORCH_BACKEND="torch_gcu"):
+            with self.assertRaisesRegex(RuntimeError, "Valid values"):
+                build_config.resolve_torch_backend("enflame")
+
+    def test_vendor_device_configs_remain_vendor_only(self):
+        torch_npu = types.ModuleType("torch_npu")
+        torch_npu.__file__ = "/opt/torch_npu/torch_npu/__init__.py"
+        torch_gcu = types.ModuleType("torch_gcu")
+        torch_gcu.__file__ = "/opt/torch_gcu/torch_gcu/__init__.py"
+
+        with self.clean_environment(), mock.patch.dict(
+            sys.modules,
+            {"torch_npu": torch_npu, "torch_gcu": torch_gcu},
+        ):
+            ascend_backend = build_config.resolve_torch_backend("ascend")
+            ascend = build_config.get_device_config(
+                build_config.ADAPTOR_MAP["ascend"], ascend_backend
+            )
+            enflame_backend = build_config.resolve_torch_backend("enflame")
+            enflame = build_config.get_device_config(
+                build_config.ADAPTOR_MAP["enflame"], enflame_backend
+            )
+
+        self.assertEqual(ascend[0], ["/opt/torch_npu/torch_npu/include"])
+        self.assertEqual(ascend[1], ["/opt/torch_npu/torch_npu/lib"])
+        self.assertEqual(ascend[2], ["torch_npu"])
+        self.assertEqual(
+            enflame,
+            (
+                ["/opt/tops/include", "/opt/torch_gcu/torch_gcu/include"],
+                ["/opt/tops/lib", "/opt/torch_gcu/torch_gcu/lib"],
+                ["topsrt", "torch_gcu"],
+            ),
+        )
+        self.assertNotIn("flagos", ascend[2])
+        self.assertNotIn("flagos", enflame[2])
+
+    def test_flagos_device_configs_do_not_load_vendor_packages(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            install_path = Path(temp_dir)
+            include_dir = install_path / "include"
+            library_dir = install_path / "lib"
+            include_dir.mkdir()
+            library_dir.mkdir()
+            (include_dir / "flagos.h").touch()
+            (library_dir / "libflagos.so").touch()
+
+            with self.clean_environment(
+                FLAGCX_TORCH_BACKEND="flagos",
+                FLAGOS_INSTALL_PATH=str(install_path),
+                ASCEND_HOME_PATH="/opt/ascend",
+            ):
+                ascend_backend = build_config.resolve_torch_backend("ascend")
+                ascend = build_config.get_device_config(
+                    build_config.ADAPTOR_MAP["ascend"], ascend_backend
+                )
+                enflame_backend = build_config.resolve_torch_backend("enflame")
+                enflame = build_config.get_device_config(
+                    build_config.ADAPTOR_MAP["enflame"], enflame_backend
+                )
+
+        self.assertEqual(
+            ascend,
+            (
+                ["/opt/ascend/include", str(include_dir)],
+                ["/opt/ascend/lib64", str(library_dir)],
+                ["ascendcl", "flagos"],
+            ),
+        )
+        self.assertEqual(
+            enflame,
+            (
+                ["/opt/tops/include", str(include_dir)],
+                ["/opt/tops/lib", str(library_dir)],
+                ["topsrt", "flagos"],
+            ),
+        )
+        self.assertNotIn("torch_npu", sys.modules)
+        self.assertNotIn("torch_gcu", sys.modules)
+
+    def test_rpaths_preserve_flagos_library_directory(self):
+        paths = ["/opt/device/lib", "/opt/flagos/lib"]
+        self.assertEqual(
+            build_config.get_device_rpath_dirs("unused", paths), paths
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ from _build_config import (
     detect_adaptor,
     detect_torch_flag,
     get_device_config,
+    get_device_rpath_dirs,
     get_ext_classes,
 )
 
@@ -38,6 +39,10 @@ print(f"[flagcx] Using {adaptor} adaptor")
 adaptor_flag = ADAPTOR_MAP[adaptor]
 adaptor_make_flag = ADAPTOR_TO_MAKE_FLAG[adaptor]
 torch_flag = detect_torch_flag()
+torch_backend_flags = []
+if adaptor == "enflame" and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
+    # Compile the Enflame plugin against torch_fl's C ABI instead of torch_gcu.
+    torch_backend_flags.append("-DFLAGCX_TORCH_BACKEND_FLAGOS")
 
 # ---------------------------------------------------------------------------
 # Extension sources and include dirs
@@ -133,7 +138,10 @@ if BuildExtension is not None:
                 # Set $ORIGIN rpath so _C.so finds libflagcx.so in the same directory
                 # Preserve device-specific rpaths so runtime linker can find device libs
                 origin_rpath = "-Wl,-rpath,$ORIGIN"
-                dev_rpaths = ["-Wl,-rpath," + d for d in dev_libdirs]
+                dev_rpaths = [
+                    "-Wl,-rpath," + d
+                    for d in get_device_rpath_dirs(adaptor_flag, dev_libdirs)
+                ]
                 ext.extra_link_args = [
                     arg for arg in ext.extra_link_args
                     if not arg.startswith("-Wl,-rpath,")
@@ -171,7 +179,9 @@ if CppExtension is not None:
         name="flagcx._C",
         sources=sources,
         include_dirs=include_dirs,
-        extra_compile_args={"cxx": [adaptor_flag, torch_flag]},
+        extra_compile_args={
+            "cxx": [adaptor_flag, torch_flag] + torch_backend_flags
+        },
         extra_link_args=[],
         library_dirs=library_dirs,
         libraries=libs,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ from _build_config import (
     get_device_config,
     get_device_rpath_dirs,
     get_ext_classes,
+    resolve_torch_backend,
 )
 
 # ---------------------------------------------------------------------------
@@ -39,10 +40,9 @@ print(f"[flagcx] Using {adaptor} adaptor")
 adaptor_flag = ADAPTOR_MAP[adaptor]
 adaptor_make_flag = ADAPTOR_TO_MAKE_FLAG[adaptor]
 torch_flag = detect_torch_flag()
-torch_backend_flags = []
-if adaptor == "enflame" and os.environ.get("FLAGCX_TORCH_BACKEND", "").strip().lower() == "flagos":
-    # Compile the Enflame plugin against torch_fl's C ABI instead of torch_gcu.
-    torch_backend_flags.append("-DFLAGCX_TORCH_BACKEND_FLAGOS")
+torch_backend = resolve_torch_backend(adaptor)
+torch_backend_flags = list(torch_backend.compile_flags)
+print(f"[flagcx] Using {torch_backend.name} torch backend")
 
 # ---------------------------------------------------------------------------
 # Extension sources and include dirs
@@ -69,7 +69,9 @@ library_dirs = []
 libs = ["flagcx"]
 
 # Add device-specific paths
-dev_includes, dev_libdirs, dev_libs = get_device_config(adaptor_flag)
+dev_includes, dev_libdirs, dev_libs = get_device_config(
+    adaptor_flag, torch_backend
+)
 include_dirs += dev_includes
 library_dirs += dev_libdirs
 libs += dev_libs
@@ -140,7 +142,9 @@ if BuildExtension is not None:
                 origin_rpath = "-Wl,-rpath,$ORIGIN"
                 dev_rpaths = [
                     "-Wl,-rpath," + d
-                    for d in get_device_rpath_dirs(adaptor_flag, dev_libdirs)
+                    for d in get_device_rpath_dirs(
+                        adaptor_flag, dev_libdirs, torch_backend
+                    )
                 ]
                 ext.extra_link_args = [
                     arg for arg in ext.extra_link_args


### PR DESCRIPTION
### PR Category
PAL (Portable Abstraction Layer)

### PR Types
Bug Fixes

### PR Description

This follow-up completes the opt-in `FLAGCX_TORCH_BACKEND=flagos` Enflame GCU path introduced by #546. It keeps the PR #1 architecture and does not import or link `torch_gcu`.

The changes:

- Route FlagOS intermediate tensor allocations and all list-collective flatten/unflatten copies through the FlagCX communication stream.
- Use the FlagCX device API for same-stream device-to-device copies, avoiding the unreliable Enflame ATen `int64 copy_` path.
- Synchronize the Enflame FlagCX communication stream for host-visible `Work.wait()` and `getFuture()` completion.
- Work around the tested ECCL runtime's gather/scatter behavior while preserving PyTorch gather/scatter semantics in FlagOS Enflame mode.
- Add source-level regression coverage for stream copies and the Enflame collective fallbacks.

### Root Cause

The original FlagOS integration shared stream and event handles with torch-fl, but temporary collective buffers were not consistently protected by communication-stream allocation and copy ordering. In addition, the tested ECCL runtime did not populate gather/scatter output buffers as expected by the PyTorch process-group API. Host-side tensor reads also could occur before queued communication-stream work completed.

### Investigation

The failure was reproduced on a two-card Enflame GCU system with allocator churn. The failure moved from list `all_to_all` to gather after stream-aware allocation and explicit work completion were added, isolating the remaining issues to intermediate copies and ECCL gather/scatter behavior. Replacing ATen copies with same-stream FlagCX D2D copies and using tested all-gather/broadcast fallbacks resolved the failures.

### Validation

Actual hardware results:

- FlagCX Python tests: `14 passed in 0.09s`
- Two-card Enflame FlagOS collective smoke with allocator churn: `PASS: adaptor=enflame backend=flagos`
- Two-card Enflame DDP: `DDP test passed`
- Two-card Enflame FSDP2: `FSDP2 test passed`
- Final wheel import: `torch_gcu_spec=None`, `torch_gcu_loaded=False`, `flagcx_capability=('flagos',)`
- ELF inspection: extension depends on `libflagos.so` and `libtopsrt.so.1`; no `libtorch_gcu.so` dependency; `devApiBackend` is exported.
- `git diff --check`: passed
- `ruff check` and `ruff format --check` for modified Python tests: passed

### Edge Cases

- The workaround is restricted to `FLAGCX_TORCH_BACKEND_FLAGOS` plus `USE_ENFLAME_ADAPTOR`; existing vendor and non-Enflame paths retain their original collectives.
- Non-root gather and root scatter temporary buffers are sized for the complete communicator before the collective is queued.
- Host-visible completion restores the caller's previous device after synchronizing the FlagCX communication stream.

### Dependency Note

The two-card allocator-churn validation uses the corresponding torch-fl allocator change that associates allocations with the FlagOS current stream. That torch-fl change is maintained in the companion PyTorch-Plugin-FL worktree.

### Reviewer

Please assign a human reviewer familiar with FlagCX and Enflame GCU stream semantics.
