### PR TITLE
[Others] Adapt new FlagCX interfaces for MetaX backend

### DIFF
--- a/flagcx/adaptor/ccl/mccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/mccl_adaptor.cc
@@ -89,21 +89,65 @@ flagcxResult_t mcclAdaptorCommGetAsyncError(flagcxInnerComm_t comm,
                                                (mcclResult_t *)asyncError);
 }
 
-// TODO: unsupported
+#if MCCL_VERSION_CODE >= MCCL_VERSION(2, 30, 4)
+flagcxResult_t mcclAdaptorMemAlloc(void **ptr, size_t size) {
+  return (flagcxResult_t)mcclMemAlloc(ptr, size);
+}
+
+flagcxResult_t mcclAdaptorMemFree(void *ptr) {
+  return (flagcxResult_t)mcclMemFree(ptr);
+}
+
+flagcxResult_t mcclAdaptorCommRegister(flagcxInnerComm_t comm, void *buff,
+                                       size_t size, void **handle) {
+  return (flagcxResult_t)mcclCommRegister(comm->base, buff, size, handle);
+}
+
+flagcxResult_t mcclAdaptorCommDeregister(flagcxInnerComm_t comm, void *handle) {
+  return (flagcxResult_t)mcclCommDeregister(comm->base, handle);
+}
+
+flagcxResult_t mcclAdaptorCommWindowRegister(flagcxInnerComm_t comm, void *buff,
+                                             size_t size,
+                                             flagcxInnerWindow_t *win,
+                                             int winFlags) {
+  if (*win == NULL) {
+    FLAGCXCHECK(flagcxCalloc(win, 1));
+  }
+  mcclWindow_t mcclWin = NULL;
+  flagcxResult_t res = (flagcxResult_t)mcclCommWindowRegister(
+      comm->base, buff, size, &mcclWin, winFlags);
+  if (res == flagcxSuccess) {
+    (*win)->base = mcclWin;
+    (*win)->winFlags = winFlags;
+  } else {
+    free(*win);
+    *win = NULL;
+  }
+  return res;
+}
+
+flagcxResult_t mcclAdaptorCommWindowDeregister(flagcxInnerComm_t comm,
+                                               flagcxInnerWindow_t win) {
+  flagcxResult_t res = flagcxSuccess;
+  res = (flagcxResult_t)mcclCommWindowDeregister(comm->base, win->base);
+  free(win);
+  return res;
+}
+#else  //MCCL_VERSION_CODE < MCCL_VERSION(2, 30, 4)
 flagcxResult_t mcclAdaptorMemAlloc(void **ptr, size_t size) {
   return flagcxNotSupported;
 }
 
-// TODO: unsupported
-flagcxResult_t mcclAdaptorMemFree(void *ptr) { return flagcxNotSupported; }
+flagcxResult_t mcclAdaptorMemFree(void *ptr) {
+  return flagcxNotSupported;
+}
 
-// TODO: unsupported
 flagcxResult_t mcclAdaptorCommRegister(flagcxInnerComm_t comm, void *buff,
                                        size_t size, void **handle) {
   return flagcxNotSupported;
 }
 
-// TODO: unsupported
 flagcxResult_t mcclAdaptorCommDeregister(flagcxInnerComm_t comm, void *handle) {
   return flagcxNotSupported;
 }
@@ -119,6 +163,7 @@ flagcxResult_t mcclAdaptorCommWindowDeregister(flagcxInnerComm_t comm,
                                                flagcxInnerWindow_t win) {
   return flagcxNotSupported;
 }
+#endif  // MCCL_VERSION_CODE >= MCCL_VERSION(2, 30, 4)
 
 flagcxResult_t mcclAdaptorReduce(const void *sendbuff, void *recvbuff,
                                  size_t count, flagcxDataType_t datatype,

--- a/flagcx/adaptor/device/maca_adaptor.cc
+++ b/flagcx/adaptor/device/maca_adaptor.cc
@@ -101,6 +101,14 @@ flagcxResult_t macaAdaptorGetVendor(char *vendor) {
   return flagcxSuccess;
 }
 
+flagcxResult_t macaAdaptorHostGetDevicePointer(void **pDevice, void *pHost) {
+  if (pDevice == NULL || pHost == NULL) {
+    return flagcxInvalidArgument;
+  }
+  DEVCHECK(mcHostGetDevicePointer(pDevice, pHost, 0));
+  return flagcxSuccess;
+}
+
 flagcxResult_t macaAdaptorGdrMemAlloc(void **ptr, size_t size,
                                       void *memHandle) {
   if (ptr == NULL) {
@@ -351,42 +359,338 @@ flagcxResult_t macaAdaptorStreamWriteValue64(flagcxStream_t, void *, uint64_t,
   return flagcxNotSupported;
 }
 
-flagcxResult_t macaAdaptorHostRegister(void *, size_t) {
-  return flagcxNotSupported;
+flagcxResult_t
+macaAdaptorMemGetHandleForAddressRange(void *handleOut, void *buffer,
+                                       size_t size, unsigned long long flags) {
+  // MCdeviceptr dptr = (MCdeviceptr)buffer;
+  DEVCHECK(mcMemGetHandleForAddressRange(handleOut, buffer, size, 0x1, flags));
+  return flagcxSuccess;
 }
-flagcxResult_t macaAdaptorHostUnregister(void *) { return flagcxNotSupported; }
 
-// Symmetric memory VMM stubs (not supported)
-flagcxResult_t macaAdaptorSymPhysAlloc(void *, size_t, void **, void *,
-                                       size_t *, size_t *) {
-  return flagcxNotSupported;
+flagcxResult_t macaAdaptorHostRegister(void *ptr, size_t size) {
+  if (ptr == NULL || size == 0) {
+    return flagcxInvalidArgument;
+  }
+  DEVCHECK(mcHostRegister(ptr, size, mcHostRegisterMapped));
+  return flagcxSuccess;
 }
-flagcxResult_t macaAdaptorSymPhysFree(void *) { return flagcxNotSupported; }
-flagcxResult_t macaAdaptorSymFlatMap(void *[], int, int, void *, size_t,
-                                     void **) {
-  return flagcxNotSupported;
+flagcxResult_t macaAdaptorHostUnregister(void *ptr) {
+  if (ptr == NULL) {
+    return flagcxInvalidArgument;
+  }
+  DEVCHECK(mcHostUnregister(ptr));
+  return flagcxSuccess;
 }
-flagcxResult_t macaAdaptorSymFlatUnmap(void *, size_t, int) {
-  return flagcxNotSupported;
+
+flagcxResult_t macaAdaptorSymPhysAlloc(void *ptr, size_t size,
+                                       void **physHandle, void *shareableHandle,
+                                       size_t *handleSize, size_t *allocSize) {
+  if (ptr == NULL || physHandle == NULL || shareableHandle == NULL ||
+      handleSize == NULL || allocSize == NULL)
+    return flagcxInvalidArgument;
+
+  mcMemGenericAllocationHandle *mcHandle =
+      (mcMemGenericAllocationHandle *)malloc(
+          sizeof(mcMemGenericAllocationHandle));
+  if (mcHandle == NULL)
+    return flagcxSystemError;
+
+  // Retain the physical allocation handle from the VMM-backed pointer
+  DEVCHECK(mcMemRetainAllocationHandle(mcHandle, ptr));
+
+  // Discover actual physical allocation size (already granularity-aligned)
+  size_t actualAllocSize = 0;
+  DEVCHECK(mcMemGetAddressRange(NULL, &actualAllocSize, ptr));
+  *allocSize = actualAllocSize;
+
+  // Export as POSIX fd for IPC sharing
+  if (*handleSize < sizeof(int)) {
+    free(mcHandle);
+    return flagcxInvalidArgument;
+  }
+  DEVCHECK(mcMemExportToShareableHandle(shareableHandle, *mcHandle,
+                                        mcMemHandleTypePosixFileDescriptor, 0));
+  *handleSize = sizeof(int); // POSIX fd is an int
+  *physHandle = mcHandle;
+  return flagcxSuccess;
 }
+
+// flagcxResult_t macaAdaptorSymPhysFree(void *) { return flagcxNotSupported; }
+flagcxResult_t macaAdaptorSymPhysFree(void *physHandle) {
+  if (physHandle == NULL)
+    return flagcxSuccess;
+  mcMemGenericAllocationHandle *mcHandle =
+      (mcMemGenericAllocationHandle *)physHandle;
+  mcMemRelease(*mcHandle);
+  free(mcHandle);
+  return flagcxSuccess;
+}
+
+flagcxResult_t macaAdaptorSymFlatMap(void *peerHandles[], int nPeers,
+                                     int selfIndex, void *selfPhysHandle,
+                                     size_t allocSize, void **flatBase) {
+  if (peerHandles == NULL || selfPhysHandle == NULL || flatBase == NULL ||
+      nPeers <= 0 || allocSize == 0)
+    return flagcxInvalidArgument;
+
+  mcMemGenericAllocationHandle selfHandle =
+      *(mcMemGenericAllocationHandle *)selfPhysHandle;
+
+  // allocSize is already granularity-aligned (from mcMemGetAddressRange)
+  size_t totalSize = allocSize * nPeers;
+
+  // Reserve the full VA range
+  mcDeviceptr_t base = 0;
+  DEVCHECK(mcMemAddressReserve(&base, totalSize, 0, 0, 0));
+
+  // Import and map each peer's physical memory
+  int macaDev;
+  DEVCHECK(mcGetDevice(&macaDev));
+  mcMemAccessDesc accessDesc = {};
+  accessDesc.location.type = mcMemLocationTypeDevice;
+  accessDesc.location.id = macaDev;
+  accessDesc.flags = mcMemAccessFlagsProtReadWrite;
+
+  for (int i = 0; i < nPeers; i++) {
+    mcMemGenericAllocationHandle peerHandle;
+    if (i == selfIndex) {
+      peerHandle = selfHandle;
+    } else {
+      int fd = *(int *)peerHandles[i];
+      DEVCHECK(
+          mcMemImportFromShareableHandle(&peerHandle, (void *)(uintptr_t)fd,
+                                         mcMemHandleTypePosixFileDescriptor));
+    }
+    mcDeviceptr_t slot =
+        (mcDeviceptr_t)((uintptr_t)base + (uint64_t)i * allocSize);
+    DEVCHECK(mcMemMap(slot, allocSize, 0, peerHandle, 0));
+    DEVCHECK(mcMemSetAccess(slot, allocSize, &accessDesc, 1));
+    if (i != selfIndex) {
+      mcMemRelease(peerHandle);
+    }
+  }
+
+  *flatBase = (void *)base;
+  return flagcxSuccess;
+}
+
+flagcxResult_t macaAdaptorSymFlatUnmap(void *flatBase, size_t allocSize,
+                                       int nPeers) {
+  if (flatBase == NULL)
+    return flagcxSuccess;
+  mcDeviceptr_t base = (mcDeviceptr_t)flatBase;
+  size_t totalSize = allocSize * nPeers;
+  DEVCHECK(mcMemUnmap(base, totalSize));
+  DEVCHECK(mcMemAddressFree(base, totalSize));
+  return flagcxSuccess;
+}
+
 flagcxResult_t macaAdaptorSymMulticastSupported(int *supported) {
-  if (supported)
+  if (supported == NULL)
+    return flagcxInvalidArgument;
+  *supported = 0;
+  int macaDev;
+  DEVCHECK(mcGetDevice(&macaDev));
+  MCdevice dev;
+  DEVCHECK(mcDeviceGet(&dev, macaDev));
+  mcError_t res =
+      mcDeviceGetAttribute(supported, mcDeviceAttributeMulticastSupported, dev);
+  if (res != mcSuccess)
     *supported = 0;
   return flagcxSuccess;
 }
-flagcxResult_t macaAdaptorSymMulticastCreate(size_t, int, const int *, void **,
-                                             int *) {
-  return flagcxNotSupported;
+
+flagcxResult_t macaAdaptorSymMulticastCreate(size_t allocSize,
+                                             int nLocalDevices,
+                                             const int *localDeviceOrdinals,
+                                             void **mcHandle,
+                                             int *shareableFd) {
+  if (mcHandle == NULL || shareableFd == NULL || nLocalDevices <= 0 ||
+      localDeviceOrdinals == NULL)
+    return flagcxInvalidArgument;
+  *mcHandle = NULL;
+  *shareableFd = -1;
+
+  mcMemGenericAllocationHandle handle = 0;
+  int fd = -1;
+  mcError_t err;
+
+  // Get multicast granularity and align size
+  mcMulticastObjectProp mcProp = {};
+  mcProp.numDevices = (unsigned int)nLocalDevices;
+  mcProp.size = allocSize;
+  mcProp.handleTypes = mcMemHandleTypePosixFileDescriptor;
+
+  size_t mcGran = 0;
+  err = mcMulticastGetGranularity(&mcGran, &mcProp,
+                                  MC_MULTICAST_GRANULARITY_RECOMMENDED);
+  if (err != mcSuccess)
+    return flagcxUnhandledDeviceError;
+  mcProp.size = ((allocSize + mcGran - 1) / mcGran) * mcGran;
+
+  err = mcMulticastCreate(&handle, &mcProp);
+  if (err != mcSuccess)
+    return flagcxUnhandledDeviceError;
+
+  // Add all local devices using explicit ordinals
+  for (int i = 0; i < nLocalDevices; i++) {
+    MCdevice peerDev;
+    err = mcDeviceGet(&peerDev, localDeviceOrdinals[i]);
+    if (err != mcSuccess)
+      goto cleanup_handle;
+    err = mcMulticastAddDevice(handle, peerDev);
+    if (err != mcSuccess)
+      goto cleanup_handle;
+  }
+
+  // Export as POSIX FD for sharing with peers
+  err = mcMemExportToShareableHandle(&fd, handle,
+                                     mcMemHandleTypePosixFileDescriptor, 0);
+  if (err != mcSuccess)
+    goto cleanup_handle;
+
+  // Store handle as heap-allocated value
+  {
+    mcMemGenericAllocationHandle *handlePtr =
+        (mcMemGenericAllocationHandle *)malloc(
+            sizeof(mcMemGenericAllocationHandle));
+    if (handlePtr == NULL)
+      goto cleanup_fd;
+
+    *handlePtr = handle;
+    *mcHandle = handlePtr;
+    *shareableFd = fd;
+  }
+  return flagcxSuccess;
+
+cleanup_fd:
+  close(fd);
+cleanup_handle:
+  mcMemRelease(handle);
+  return flagcxUnhandledDeviceError;
 }
-flagcxResult_t macaAdaptorSymMulticastBind(void *, int, void *, size_t, int,
-                                           int, void **, size_t *) {
-  return flagcxNotSupported;
-}
-flagcxResult_t macaAdaptorSymMulticastTeardown(void *, size_t) {
+
+flagcxResult_t macaAdaptorSymMulticastBind(void *mcHandle, int importFd,
+                                           void *physHandle, size_t allocSize,
+                                           int localRank, int nLocalDevices,
+                                           void **mcBase, size_t *mcMapSize) {
+  if (mcBase == NULL || physHandle == NULL || mcMapSize == NULL)
+    return flagcxInvalidArgument;
+  *mcBase = NULL;
+  *mcMapSize = 0;
+
+  mcMemGenericAllocationHandle mcMcHandle;
+  bool imported = (mcHandle == NULL);
+
+  if (mcHandle != NULL) {
+    // Rank 0: already has the handle from symMulticastCreate
+    mcMcHandle = *(mcMemGenericAllocationHandle *)mcHandle;
+  } else {
+    // Other ranks: import from FD
+    if (importFd < 0)
+      return flagcxInvalidArgument;
+    mcError_t res =
+        mcMemImportFromShareableHandle(&mcMcHandle, (void *)(intptr_t)importFd,
+                                       mcMemHandleTypePosixFileDescriptor);
+    if (res != mcSuccess) {
+      WARN("symMulticastBind: mcMemImportFromShareableHandle failed: %d", res);
+      return flagcxUnhandledDeviceError;
+    }
+  }
+
+  mcMemGenericAllocationHandle mcPhysHandle =
+      *(mcMemGenericAllocationHandle *)physHandle;
+
+  // Bind this rank's physical allocation to the multicast object.
+  // Use mcMulticastBindMem (takes physical handle), not mcMulticastBindAddr
+  // (which takes a virtual address).
+  mcError_t res =
+      mcMulticastBindMem(mcMcHandle, 0, mcPhysHandle, 0, allocSize, 0);
+  if (res != mcSuccess) {
+    WARN("symMulticastBind: mcMulticastBindMem failed: %d (localRank=%d "
+         "allocSize=%zu)",
+         res, localRank, allocSize);
+    if (imported)
+      mcMemRelease(mcMcHandle);
+    return flagcxUnhandledDeviceError;
+  }
+
+  // Get multicast granularity to compute aligned total size
+  mcMulticastObjectProp mcProp = {};
+  mcProp.numDevices = (unsigned int)nLocalDevices;
+  mcProp.size = allocSize;
+  mcProp.handleTypes = mcMemHandleTypePosixFileDescriptor;
+  size_t mcGran = 0;
+  res = mcMulticastGetGranularity(&mcGran, &mcProp,
+                                  MC_MULTICAST_GRANULARITY_RECOMMENDED);
+  if (res != mcSuccess) {
+    WARN("symMulticastBind: mcMulticastGetGranularity failed: %d", res);
+    if (imported)
+      mcMemRelease(mcMcHandle);
+    return flagcxUnhandledDeviceError;
+  }
+  size_t alignedSize = ((allocSize + mcGran - 1) / mcGran) * mcGran;
+
+  // Reserve VA and map the multicast handle
+  mcDeviceptr_t mcVa = 0;
+  res = mcMemAddressReserve(&mcVa, alignedSize, mcGran, 0, 0);
+  if (res != mcSuccess) {
+    WARN("symMulticastBind: mcMemAddressReserve failed: %d", res);
+    if (imported)
+      mcMemRelease(mcMcHandle);
+    return flagcxUnhandledDeviceError;
+  }
+
+  res = mcMemMap(mcVa, alignedSize, 0, mcMcHandle, 0);
+  if (res != mcSuccess) {
+    WARN("symMulticastBind: mcMemMap failed: %d", res);
+    mcMemAddressFree(mcVa, alignedSize);
+    if (imported)
+      mcMemRelease(mcMcHandle);
+    return flagcxUnhandledDeviceError;
+  }
+
+  // Set access for the current device
+  int macaDev;
+  DEVCHECK(mcGetDevice(&macaDev));
+  mcMemAccessDesc accessDesc = {};
+  accessDesc.location.type = mcMemLocationTypeDevice;
+  accessDesc.location.id = macaDev;
+  accessDesc.flags = mcMemAccessFlagsProtReadWrite;
+  res = mcMemSetAccess(mcVa, alignedSize, &accessDesc, 1);
+  if (res != mcSuccess) {
+    WARN("symMulticastBind: mcMemSetAccess failed: %d", res);
+    mcMemUnmap(mcVa, alignedSize);
+    mcMemAddressFree(mcVa, alignedSize);
+    if (imported)
+      mcMemRelease(mcMcHandle);
+    return flagcxUnhandledDeviceError;
+  }
+
+  *mcBase = (void *)mcVa;
+  *mcMapSize = alignedSize;
+  if (imported)
+    mcMemRelease(mcMcHandle);
   return flagcxSuccess;
 }
-flagcxResult_t macaAdaptorSymMulticastFree(void *) {
-  return flagcxNotSupported;
+
+flagcxResult_t macaAdaptorSymMulticastTeardown(void *mcBase, size_t mcMapSize) {
+  if (mcBase == NULL)
+    return flagcxSuccess;
+  mcDeviceptr_t va = (mcDeviceptr_t)mcBase;
+  DEVCHECK(mcMemUnmap(va, mcMapSize));
+  DEVCHECK(mcMemAddressFree(va, mcMapSize));
+  return flagcxSuccess;
+}
+
+flagcxResult_t macaAdaptorSymMulticastFree(void *mcHandle) {
+  if (mcHandle == NULL)
+    return flagcxSuccess;
+  mcMemGenericAllocationHandle handle =
+      *(mcMemGenericAllocationHandle *)mcHandle;
+  DEVCHECK(mcMemRelease(handle));
+  free(mcHandle);
+  return flagcxSuccess;
 }
 
 struct flagcxDeviceAdaptor macaAdaptor {
@@ -395,7 +699,7 @@ struct flagcxDeviceAdaptor macaAdaptor {
       macaAdaptorDeviceSynchronize, macaAdaptorDeviceMemcpy,
       macaAdaptorDeviceMemset, macaAdaptorDeviceMalloc, macaAdaptorDeviceFree,
       macaAdaptorSetDevice, macaAdaptorGetDevice, macaAdaptorGetDeviceCount,
-      macaAdaptorGetVendor, NULL,
+      macaAdaptorGetVendor, macaAdaptorHostGetDevicePointer,
       // GDR functions
       NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
       NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
@@ -440,8 +744,11 @@ struct flagcxDeviceAdaptor macaAdaptor {
       macaAdaptorLaunchHostFunc,
       // DMA buffer
       NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
+      macaAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                              // (*memGetHandleForAddressRange)(void
+                                              // *handleOut, void *buffer,
+                                              // size_t size, unsigned long long
+                                              // flags);
       macaAdaptorHostRegister,   // flagcxResult_t (*hostRegister)(void *,
                                  // size_t);
       macaAdaptorHostUnregister, // flagcxResult_t (*hostUnregister)(void *);

--- a/flagcx/adaptor/include/metax_adaptor.h
+++ b/flagcx/adaptor/include/metax_adaptor.h
@@ -9,7 +9,19 @@
 #include "mccl.h"
 #include <map>
 #include <mcr/mc_runtime.h>
+#if MCCL_VERSION_CODE >= MCCL_VERSION(2, 30, 4)
+#include "mccl/mccl_device.h"
+
+struct flagcxInnerDevComm {
+  mcclDevComm base;
+};
+struct flagcxInnerWindow {
+  mcclWindow_t base;
+  int winFlags;
+};
+#else
 struct flagcxInnerDevComm {};
+#endif
 
 struct flagcxInnerComm {
   mcclComm_t base;

--- a/makefiles/metax.mk
+++ b/makefiles/metax.mk
@@ -3,7 +3,7 @@
 
 DEVICE_HOME  ?= /opt/maca
 DEVICE_LIB   := $(DEVICE_HOME)/lib64
-DEVICE_INCLUDE := $(DEVICE_HOME)/include
+DEVICE_INCLUDE := $(DEVICE_HOME)/include $(DEVICE_HOME)/include/mcr
 DEVICE_LINK  := -lmcruntime -lmccompiler
 DEVICE_PLATFORM := MACA
 DEVICE_COMPILER := $(DEVICE_HOME)/mxgpu_llvm/bin/mxcc
@@ -13,7 +13,7 @@ DEVICE_FILE_EXTENSION := cu
 
 CCL_HOME    ?= /opt/maca
 CCL_LIB     := $(CCL_HOME)/lib64
-CCL_INCLUDE := $(CCL_HOME)/include
+CCL_INCLUDE := $(CCL_HOME)/include/mccl
 CCL_LINK    := -lmccl
 ADAPTOR_FLAG := -DUSE_METAX_ADAPTOR
 


### PR DESCRIPTION
PR Category
Others

PR Types
New Features

PR Description
[adaptor/metax] Implement adaptation for new FlagCX interfaces:
memAlloc
memFree
commRegister
commDeregister
commWindowRegister
commWindowDeregister
getHandleForAddressRange
hostGetDevicePointer
hostRegister
hostUnregister
symPhysAlloc
symPhysFree
symFlatMap
symFlatUnmap
symMulticastSupported
symMulticastCreate
symMulticastBind
symMulticastTeardown
symMulticastFree